### PR TITLE
Rename schema/UI term "tool" to "project"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,11 @@ Add `data/<slug>.json`:
       "slug": "<slug>",
       "name": "Display Name",
       "description": "One-line description shown on the landing page.",
-      "tools": [
+      "projects": [
         {
           "id": "owner/repo",
           "path": ["Category Name"],
-          "name": "Some Tool",
+          "name": "Some Project",
           "link": "https://example.com",
           "desc": "What it does.",
           "weight": 1000
@@ -70,15 +70,15 @@ Add `data/<slug>.json`:
       ]
     }
 
-- `id` and `path` are required on every tool, and `id` doubles as the
-  tool's GitHub repo — it's always `owner/repo` (github.com only, so the
-  host isn't repeated per tool), no full URL. For a tool with no public
+- `id` and `path` are required on every project, and `id` doubles as the
+  project's GitHub repo — it's always `owner/repo` (github.com only, so the
+  host isn't repeated per project), no full URL. For a project with no public
   GitHub repo, use any other unique string as `id`; it just won't be
   enriched (see below), so give it `weight` yourself. `path` is the
-  breadcrumb of category names from root to the tool (a single-level
+  breadcrumb of category names from root to the project (a single-level
   category is a one-element array; deeper nesting is a longer array).
 - `name`, `desc`, `link`, and `weight` may be omitted.
-- Logos aren't stored in this repo. Set `image` on the tool to a direct
+- Logos aren't stored in this repo. Set `image` on the project to a direct
   URL into its source (e.g. a `raw.githubusercontent.com` link) and it's
   hotlinked as-is; `node scripts/enrich-domain.mjs data/<slug>.json` fills
   this in automatically from the repo's logo file, when `id` is an
@@ -92,15 +92,15 @@ Every domain map has a second sizing mode, "Rising," that sizes tiles by
 star-growth velocity (7/30/90-day windows) instead of total star count.
 This is entirely generated data — nothing here is hand-authored:
 
-- `data/history/<slug>.json` is a per-tool star-count snapshot log,
+- `data/history/<slug>.json` is a per-project star-count snapshot log,
   written daily by `.github/workflows/snapshot-history.yml` (running
-  `scripts/snapshot-history.mjs`). It's keyed by tool `id`, each value an
+  `scripts/snapshot-history.mjs`). It's keyed by project `id`, each value an
   array of `{ date, stars }` entries, pruned to the last 120 days.
 - `scripts/generate.mjs` reads that history at build time and computes
-  each tool's `sizes` (`popular`, `rising7`, `rising30`, `rising90`),
+  each project's `sizes` (`popular`, `rising7`, `rising30`, `rising90`),
   `hasEnoughHistory`, and `growth` fields via `scripts/velocity.mjs` —
   these never need to be set by hand in `data/<slug>.json`.
-- A brand-new tool (or a brand-new domain) simply has no history yet;
+- A brand-new project (or a brand-new domain) simply has no history yet;
   it renders in Rising mode with a "not enough history" marker until the
   daily snapshot job has run long enough to cover the selected window.
 - To manually trigger a snapshot run locally: `node

--- a/README.md
+++ b/README.md
@@ -6,24 +6,24 @@
 
 **[→ Explore the live maps](https://haggaishachar.github.io/awesomemap/)**
 
-Interactive, zoomable treemaps of open-source tool ecosystems. Every
-rectangle is a tool; its size reflects adoption, and its place in the map
+Interactive, zoomable treemaps of open-source project ecosystems. Every
+rectangle is a project; its size reflects adoption, and its place in the map
 is its category. Zoom into a category to see what's inside it, click any
-tool to see what it does and jump to its GitHub repo or homepage.
+project to see what it does and jump to its GitHub repo or homepage.
 
 ## Popular vs. Rising
 
 Every map has two modes:
 
-- **Popular** sizes each tool by total adoption — the established players.
-- **Rising** sizes each tool by star-growth *velocity* over the last 7,
+- **Popular** sizes each project by total adoption — the established players.
+- **Rising** sizes each project by star-growth *velocity* over the last 7,
   30, or 90 days, computed from daily star-history snapshots — surfaces
   what's accelerating right now, before it shows up on the "popular"
   radar.
 
 ## Maps
 
-| Map | Description | Tools |
+| Map | Description | Projects |
 | --- | --- | --- |
 | [Data Science](https://haggaishachar.github.io/awesomemap/data-science/) | Machine learning, deep learning, NLP, computer vision, and more. | 44 |
 | [Security](https://haggaishachar.github.io/awesomemap/security/) | Scanning, exploitation, SIEM, secrets management, forensics, and more. | 51 |
@@ -35,9 +35,9 @@ More domains are on the way.
 
 ## How it works
 
-- Each map is a curated, hand-weighted dataset of tools grouped by category.
+- Each map is a curated, hand-weighted dataset of projects grouped by category.
 - Click a category to zoom in; use the breadcrumb to zoom back out.
-- Click any tool for a detail panel with its description, GitHub link, and homepage.
+- Click any project for a detail panel with its description, GitHub link, and homepage.
 - Toggle Popular/Rising and pick a growth window to see what's trending.
 
 ## Embed a map
@@ -56,5 +56,5 @@ Swap `data-science` for any slug from the table above.
 
 ## Contributing
 
-Want to add a tool, fix a map, or run awesomemap locally? See
+Want to add a project, fix a map, or run awesomemap locally? See
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/data/data-science.json
+++ b/data/data-science.json
@@ -1,8 +1,8 @@
 {
   "slug": "data-science",
-  "name": "Best Data Science Open Source Tools",
+  "name": "Best Data Science Open Source Projects",
   "description": "Machine learning, deep learning, NLP, computer vision, and more.",
-  "tools": [
+  "projects": [
     {
       "id": "scikit-learn/scikit-learn",
       "path": [

--- a/data/devops-infra.json
+++ b/data/devops-infra.json
@@ -1,8 +1,8 @@
 {
   "slug": "devops-infra",
-  "name": "Best DevOps & Infrastructure Open Source Tools",
+  "name": "Best DevOps & Infrastructure Open Source Projects",
   "description": "Containers, orchestration, CI/CD, infrastructure as code, observability, and more.",
-  "tools": [
+  "projects": [
     {
       "id": "moby/moby",
       "path": [

--- a/data/mobile-dev.json
+++ b/data/mobile-dev.json
@@ -1,8 +1,8 @@
 {
   "slug": "mobile-dev",
-  "name": "Best Mobile Development Open Source Tools",
+  "name": "Best Mobile Development Open Source Projects",
   "description": "Cross-platform frameworks, native tooling, testing, state management, and more.",
-  "tools": [
+  "projects": [
     {
       "id": "react/react-native",
       "path": [

--- a/data/security.json
+++ b/data/security.json
@@ -1,8 +1,8 @@
 {
   "slug": "security",
-  "name": "Best Security Open Source Tools",
+  "name": "Best Security Open Source Projects",
   "description": "Scanning, exploitation, SIEM, secrets management, forensics, and more.",
-  "tools": [
+  "projects": [
     {
       "id": "nmap/nmap",
       "path": [

--- a/data/web-dev.json
+++ b/data/web-dev.json
@@ -1,8 +1,8 @@
 {
   "slug": "web-dev",
-  "name": "Best Web Development Open Source Tools",
+  "name": "Best Web Development Open Source Projects",
   "description": "Frontend frameworks, build tools, styling, backend frameworks, and more.",
-  "tools": [
+  "projects": [
     {
       "id": "facebook/react",
       "path": [

--- a/docs/superpowers/specs/2026-08-08-treemap-top-n-others-design.md
+++ b/docs/superpowers/specs/2026-08-08-treemap-top-n-others-design.md
@@ -1,6 +1,6 @@
 # Treemap Top-N + Others — Design
 
-Status: Approved
+Status: Superseded by [`2026-08-12-treemap-icon-grid-design.md`](2026-08-12-treemap-icon-grid-design.md)
 Date: 2026-08-08
 
 ## Context

--- a/docs/superpowers/specs/2026-08-12-treemap-icon-grid-design.md
+++ b/docs/superpowers/specs/2026-08-12-treemap-icon-grid-design.md
@@ -1,0 +1,199 @@
+# Treemap Recursive Icon Grid — Design
+
+Status: Approved
+Date: 2026-08-12
+
+Supersedes: [`2026-08-08-treemap-top-n-others-design.md`](2026-08-08-treemap-top-n-others-design.md)
+(approved but never implemented — no code or plan doc ever followed it).
+That spec's two-mechanism split (a decorative "peek" strip inside
+label-only category boxes, plus a separate full-leaf-treemap-with-safety-
+net once zoomed in) is replaced here by one mechanism used at every depth.
+Its `selectTopWithOthers`/`estimateCapacity` shape is reused.
+
+## Context
+
+Today, `renderLevel()` in `app/shared/treemap.js` draws exactly one level
+of the hierarchy at a time — `focusNode.children` — and only leaf nodes get
+a logo; a category box is label-only until you zoom into it
+(`treemap.js:139-165`). Every child is always drawn, however many there
+are, so a category with many tools gets many illegibly thin boxes instead
+of a curated view. This was fine for the original single-domain map;
+across five domains, and with real logos about to land for most tools
+(see the image-coverage work landing alongside this), it's the first
+impression of every map.
+
+The reference point for this design is a "logo landscape" layout (e.g.
+chiefmartec's Marketing Technology Landscape): each region shows a curated
+set of the most important logos, sized by importance, with an overflow
+indicator for the rest.
+
+## Goals
+
+- Every box that has children — at any depth, including the map root —
+  shows a preview of its own top tools as logos, not just a label.
+- The preview always fits the box: as a box grows (root → zoomed
+  category → zoomed sub-group), more of its children are promoted from
+  "hidden" to "shown," and shown icons render larger.
+- Degrades gracefully to hundreds of tools in one category: only the most
+  important ones are ever drawn as icons; the rest collapse into a single
+  "Others" tile, itself drillable the same way.
+- One rendering mechanism, reused recursively, rather than special-casing
+  "root," "zoomed-in," and "too many children" separately.
+- Stay unit-testable without a browser (matches existing test convention —
+  no jsdom/browser-automation tests in this repo).
+
+## Non-goals
+
+- No data schema changes. `path` stays whatever depth it already is;
+  today every domain is two levels (root → category → tool) but nothing
+  here assumes that — a category-of-categories renders the same way a
+  category-of-tools does.
+- No change to the zoom/breadcrumb navigation model itself (`zoomTo()`,
+  `focusIdPath`) — "Others" reuses it rather than replacing it.
+- No change to how the *category* level's own box area is computed —
+  that's still today's weight-proportional squarify treemap. This spec
+  only changes what's drawn *inside* a box.
+
+## Design
+
+### One renderer, every depth
+
+Any node with children — a real category, or a synthetic "Others" bucket
+(below) — is drawn as: a label, plus a preview grid of its own direct
+children, sized to whatever pixel rect the box currently has. There is no
+separate "collapsed root" vs "zoomed" rendering path: zooming just means
+`zoomTo()` makes that node's box fill the stage, so the *same* renderer
+runs again with a bigger rect, and naturally promotes more children out of
+"Others" (bigger rect → higher capacity). Reaching a category whose
+children are leaf tools (rather than sub-categories) renders identically —
+top-N tool icons plus an Others tile if there are more than fit.
+
+Clicking a shown icon (leaf or category) still does what it does today:
+a leaf opens its detail panel directly; a category zooms in. Clicking the
+"Others" tile zooms into it exactly like a category (see below). Clicking
+elsewhere in the box (label, empty space) zooms into that box, unchanged
+from today.
+
+### Selecting what's shown: `selectTopWithOthers` + `estimateCapacity`
+
+Reused from the shelved spec, in `app/shared/layout.js`:
+
+```js
+estimateCapacity(areaPx, minItemAreaPx) // → Math.max(1, Math.floor(areaPx / minItemAreaPx))
+
+selectTopWithOthers(children, capacity)
+// → { visible, othersCount, othersWeight, othersChildren }
+// children sorted by weight desc (ties by name) before slicing;
+// children.length <= capacity → passthrough, othersCount === 0
+```
+
+Both are pure functions of numbers/arrays — no DOM — so they're directly
+unit-testable. `capacity` is computed as `estimateCapacity(rectAreaPx,
+MIN_ICON_AREA_PX) - 1` whenever `children.length` might exceed it (the
+`-1` reserves a slot for the Others tile; skipped when everything fits
+without it).
+
+This is deliberately an *estimate*, not a live-measured fit: it avoids a
+browser-only measure/re-render loop and keeps the decision testable in
+plain Node. It can run a little loose (a slightly-too-small last icon) —
+acceptable for a preview grid, and simpler than exactly replicating
+flexbox's wrapping.
+
+### Icon sizing (weighted)
+
+Within the `visible` set for one box, each icon's side length:
+
+```js
+sizeForWeight(weight, { minPx, maxPx, minWeight, maxWeight })
+// linear interpolation over sqrt(weight), clamped to [minPx, maxPx]
+// minWeight === maxWeight (single visible child) → maxPx
+```
+
+`minPx`/`maxPx` themselves scale with the box's own rect (bigger box →
+bigger min/max range), so the *same* tool can render at different sizes in
+different boxes — expected, since "bigger box" already means "zoomed in,
+give me more detail." The Others tile is sized the same way, using
+`othersWeight` (the sum of hidden children's weight) as its input — a
+large hidden pile reads as a visually bigger tile than a small one.
+
+Layout of the sized icons inside the box is plain CSS flex-wrap — the
+sizing/selection decision above is what keeps it from overflowing (with
+the acceptable slack noted above); flexbox just needs to place boxes of
+known sizes, not decide how many fit.
+
+### "Others" as a zoomable synthetic node
+
+`selectTopWithOthers`'s `othersChildren` becomes a synthetic node on
+click:
+
+```js
+{ id: `${parentId}__others`, name: `${othersCount} more`, children: othersChildren }
+```
+
+Passed through `hierarchy()` and given its own small treemap layout (via
+the existing `computeLayout`, sized to the stage — it doesn't need to
+share a coordinate space with the rest of the tree; `zoomTo()`/
+`projectRect()` only ever care about a node's rect relative to its own
+children). `zoomTo()` runs unmodified — Others is just a node with
+children as far as breadcrumb/navigation logic is concerned. This means
+Others nests arbitrarily deep for very large categories (Others → Others
+→ Others), always through the same code path.
+
+## Components
+
+- **`app/shared/layout.js`** — add `estimateCapacity`, `selectTopWithOthers`,
+  `sizeForWeight`; a `buildOthersNode(parentId, hiddenChildren)` helper for
+  the synthetic node.
+- **`app/shared/treemap.js`** —
+  - `renderBox()`: for any node with children (real or synthetic Others),
+    call a new `renderPreviewGrid(node, rectPx)` instead of/alongside the
+    label.
+  - `renderPreviewGrid(node, rectPx)`: computes capacity from `rectPx`,
+    calls `selectTopWithOthers`, sizes each visible child via
+    `sizeForWeight`, renders icons + optional Others tile.
+  - Others tile click handler: builds the synthetic node via
+    `buildOthersNode`, lays it out, and calls the existing `zoomTo()`.
+- **`app/shared/treemap.css`** — new classes: `.treemap-preview-grid`,
+  `.treemap-preview-icon`, `.treemap-others-tile`.
+
+## Data flow
+
+Unchanged upstream — `scripts/build-tree.mjs` and `data/<slug>.json` are
+not touched by this spec. Everything here operates at render time on data
+already in memory. (The separate image-coverage work improves how many
+tools *have* a logo at all — orthogonal to this spec, but this view's
+usefulness depends on it landing.)
+
+## Error handling
+
+- Fewer children than capacity → passthrough, no Others tile — identical
+  to a plain grid.
+- Box too small for even one icon at `minPx` → skip the preview grid
+  entirely, fall back to a label-only box (today's behavior).
+- Broken tool logo → existing `onerror` fallback-letter treatment
+  (`treemap.js:163`), unchanged.
+- Single visible child (capacity of 1, or only one child exists) →
+  `sizeForWeight` returns `maxPx`, no divide-by-zero from equal min/max
+  weight.
+- Zero-child node (defensive; shouldn't occur) → preview grid renders
+  nothing, box behaves as a plain label-only box.
+
+## Testing
+
+- Unit tests (`node --test`, matching existing convention), all pure:
+  - `estimateCapacity`: floors correctly, minimum of 1.
+  - `selectTopWithOthers`: passthrough under capacity; correct top-K +
+    others count/weight sum when over; tie-break by name; capacity-1 and
+    capacity-0 edges.
+  - `sizeForWeight`: clamps at both ends; single-child (min===max weight)
+    case; linear interpolation midpoint check.
+  - `buildOthersNode`: id/name shape, children passthrough.
+- Manual browser verification (matching existing convention — no
+  automated browser testing): preview grid at various box sizes, Others
+  zoom-in and breadcrumb zoom-back-out, nested Others, broken-logo
+  fallback, resize behavior.
+
+## Deployment
+
+No deployment changes — same static Firebase Hosting setup, no new files
+outside `app/shared/`.

--- a/scripts/build-tree.mjs
+++ b/scripts/build-tree.mjs
@@ -1,21 +1,21 @@
 /**
- * Groups a flat list of tools (each with a `path`: array of category names
- * from root to the tool) into the nested {id, name, children} tree shape
- * the renderer expects. Categories are created implicitly from `path`
+ * Groups a flat list of projects (each with a `path`: array of category
+ * names from root to the project) into the nested {id, name, children} tree
+ * shape the renderer expects. Categories are created implicitly from `path`
  * values, in first-appearance order — there is no separate category
  * schema. `root` supplies the id/name for the tree's root node.
  *
- * Throws if any tool's `path` is not an array.
+ * Throws if any project's `path` is not an array.
  */
-export function buildTree(tools, root) {
+export function buildTree(projects, root) {
   const rootNode = { id: root.id, name: root.name, children: [] };
 
-  for (const tool of tools) {
-    if (!Array.isArray(tool.path)) {
-      throw new Error(`Tool "${tool.id}" has a non-array path`);
+  for (const project of projects) {
+    if (!Array.isArray(project.path)) {
+      throw new Error(`Project "${project.id}" has a non-array path`);
     }
     let node = rootNode;
-    for (const categoryName of tool.path) {
+    for (const categoryName of project.path) {
       let category = node.children.find((child) => child.children && child.name === categoryName);
       if (!category) {
         category = { id: categoryName, name: categoryName, children: [] };
@@ -23,8 +23,8 @@ export function buildTree(tools, root) {
       }
       node = category;
     }
-    const { path, ...leafFields } = tool;
-    node.children.push({ ...leafFields, name: tool.name ?? tool.id, desc: tool.desc ?? "" });
+    const { path, ...leafFields } = project;
+    node.children.push({ ...leafFields, name: project.name ?? project.id, desc: project.desc ?? "" });
   }
 
   return rootNode;

--- a/scripts/enrich-domain.mjs
+++ b/scripts/enrich-domain.mjs
@@ -15,8 +15,8 @@ export const LOGO_CANDIDATE_PATHS = [
 
 /**
  * Extracts { owner, repo } from a "owner/repo" shorthand (the `id` field's
- * format — always github.com, so the host isn't repeated per tool). Every
- * tool's `id` is its GitHub repo, doubling as its unique identifier.
+ * format — always github.com, so the host isn't repeated per project). Every
+ * project's `id` is its GitHub repo, doubling as its unique identifier.
  * Tolerates a trailing slash and a trailing .git. Returns null for
  * anything else, including a full URL (write the shorthand instead) or a
  * path with extra segments.
@@ -32,19 +32,19 @@ export function parseGhRepo(shorthand) {
 }
 
 /**
- * Given a tool and an injected `getJson`, returns a new tool object with
- * `weight` set to its GitHub repo's live star count and, if a logo
+ * Given a project and an injected `getJson`, returns a new project object
+ * with `weight` set to its GitHub repo's live star count and, if a logo
  * candidate is found, `image` set to that file's direct raw.githubusercontent.com
  * URL (served straight from the source repo — never downloaded or stored
- * in this repo). Tools whose `id` isn't a parseable owner/repo shorthand
+ * in this repo). Projects whose `id` isn't a parseable owner/repo shorthand
  * are returned unchanged; no network calls are made for them.
  */
-export async function enrichTool(tool, { getJson }) {
-  const repo = parseGhRepo(tool.id);
-  if (!repo) return tool;
+export async function enrichProject(project, { getJson }) {
+  const repo = parseGhRepo(project.id);
+  if (!repo) return project;
 
   const repoData = await getJson(`https://api.github.com/repos/${repo.owner}/${repo.repo}`);
-  const enriched = { ...tool, weight: repoData.stargazers_count };
+  const enriched = { ...project, weight: repoData.stargazers_count };
 
   for (const path of LOGO_CANDIDATE_PATHS) {
     let entry;
@@ -101,22 +101,22 @@ export async function withRetry(
 }
 
 /**
- * Given the post-enrichment tool list, returns the ids of tools that should
- * have received a real star-count `weight` from `enrichTool` (i.e. those
- * whose `id` is a parseable owner/repo shorthand) but didn't: `weight` is
- * missing, not a number, not an integer, or not strictly positive. Tools
- * whose `id` isn't parseable are never enriched and are intentionally
- * excluded — that's expected behavior, not a failure. Pure and
- * side-effect free so it can be unit tested directly; `main()` calls this
- * after the enrichment loop and fails loudly if it returns anything.
+ * Given the post-enrichment project list, returns the ids of projects that
+ * should have received a real star-count `weight` from `enrichProject`
+ * (i.e. those whose `id` is a parseable owner/repo shorthand) but didn't:
+ * `weight` is missing, not a number, not an integer, or not strictly
+ * positive. Projects whose `id` isn't parseable are never enriched and are
+ * intentionally excluded — that's expected behavior, not a failure. Pure
+ * and side-effect free so it can be unit tested directly; `main()` calls
+ * this after the enrichment loop and fails loudly if it returns anything.
  */
-export function findInvalidWeights(tools) {
+export function findInvalidWeights(projects) {
   const bad = [];
-  for (const tool of tools) {
-    if (!parseGhRepo(tool.id)) continue;
-    const { weight } = tool;
+  for (const project of projects) {
+    if (!parseGhRepo(project.id)) continue;
+    const { weight } = project;
     if (typeof weight !== "number" || !Number.isInteger(weight) || weight <= 0) {
-      bad.push(tool.id);
+      bad.push(project.id);
     }
   }
   return bad;
@@ -163,32 +163,32 @@ async function main() {
   let starsFetched = 0;
   let logosFound = 0;
   let failed = 0;
-  const enrichedTools = [];
+  const enrichedProjects = [];
 
-  for (const tool of domain.tools) {
+  for (const project of domain.projects) {
     try {
-      const enriched = await enrichTool(tool, { getJson });
+      const enriched = await enrichProject(project, { getJson });
       if (enriched.weight !== undefined) starsFetched += 1;
-      if (enriched.image !== undefined && enriched.image !== tool.image) logosFound += 1;
-      enrichedTools.push(enriched);
+      if (enriched.image !== undefined && enriched.image !== project.image) logosFound += 1;
+      enrichedProjects.push(enriched);
     } catch (err) {
       failed += 1;
-      console.error(`Warning: failed to enrich tool "${tool.id}": ${err.message}`);
-      enrichedTools.push(tool);
+      console.error(`Warning: failed to enrich project "${project.id}": ${err.message}`);
+      enrichedProjects.push(project);
     }
   }
 
-  const invalidWeightIds = findInvalidWeights(enrichedTools);
+  const invalidWeightIds = findInvalidWeights(enrichedProjects);
   if (invalidWeightIds.length > 0) {
     console.error(
-      `Error: ${invalidWeightIds.length} tool(s) did not end up with a real positive integer weight: ${invalidWeightIds.join(", ")}`,
+      `Error: ${invalidWeightIds.length} project(s) did not end up with a real positive integer weight: ${invalidWeightIds.join(", ")}`,
     );
     process.exit(1);
   }
 
-  writeFileSync(domainPath, JSON.stringify({ ...domain, tools: enrichedTools }, null, 2) + "\n");
+  writeFileSync(domainPath, JSON.stringify({ ...domain, projects: enrichedProjects }, null, 2) + "\n");
   console.log(
-    `${domainPath}: ${starsFetched}/${domain.tools.length} weights fetched, ${failed} failed, ${logosFound} logo URLs resolved`,
+    `${domainPath}: ${starsFetched}/${domain.projects.length} weights fetched, ${failed} failed, ${logosFound} logo URLs resolved`,
   );
 }
 

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -2,7 +2,7 @@
 import { readdirSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, rmSync, cpSync, existsSync } from "node:fs";
 import { buildTree } from "./build-tree.mjs";
 import { renderDomainPage, renderLandingPage } from "./render-page.mjs";
-import { computeToolSizing, findInvalidSizes } from "./velocity.mjs";
+import { computeProjectSizing, findInvalidSizes } from "./velocity.mjs";
 import { buildSitemap, buildRobots } from "./seo.mjs";
 
 const DATA_DIR = "data";
@@ -47,33 +47,33 @@ for (const file of domainFiles) {
   }
   seenSlugs.set(slug, domainPath);
 
-  if (!Array.isArray(domain.tools)) {
-    throw new Error(`${domainPath}: "tools" must be an array`);
+  if (!Array.isArray(domain.projects)) {
+    throw new Error(`${domainPath}: "projects" must be an array`);
   }
 
-  for (const tool of domain.tools) {
-    if (!tool.id || !Array.isArray(tool.path)) {
-      throw new Error(`${domainPath}: tool missing "id" or non-array "path": ${JSON.stringify(tool)}`);
+  for (const project of domain.projects) {
+    if (!project.id || !Array.isArray(project.path)) {
+      throw new Error(`${domainPath}: project missing "id" or non-array "path": ${JSON.stringify(project)}`);
     }
   }
 
   const historyPath = `${DATA_DIR}/history/${slug}.json`;
-  const toolHistory = existsSync(historyPath) ? JSON.parse(readFileSync(historyPath, "utf8")) : {};
+  const projectHistory = existsSync(historyPath) ? JSON.parse(readFileSync(historyPath, "utf8")) : {};
 
-  const sizedTools = domain.tools.map((tool) => {
-    const { sizes, hasEnoughHistory, growth } = computeToolSizing(tool, toolHistory[tool.id] ?? []);
-    return { ...tool, sizes, hasEnoughHistory, growth };
+  const sizedProjects = domain.projects.map((project) => {
+    const { sizes, hasEnoughHistory, growth } = computeProjectSizing(project, projectHistory[project.id] ?? []);
+    return { ...project, sizes, hasEnoughHistory, growth };
   });
 
-  const invalidSizeIds = findInvalidSizes(sizedTools);
+  const invalidSizeIds = findInvalidSizes(sizedProjects);
   if (invalidSizeIds.length > 0) {
-    throw new Error(`${domainPath}: invalid computed size(s) for tool id(s): ${invalidSizeIds.join(", ")}`);
+    throw new Error(`${domainPath}: invalid computed size(s) for project id(s): ${invalidSizeIds.join(", ")}`);
   }
 
-  // Tool `image` values (when present) are already direct URLs into the
-  // tool's source repo — set by `enrich-domain.mjs` — so no local
+  // Project `image` values (when present) are already direct URLs into the
+  // project's source repo — set by `enrich-domain.mjs` — so no local
   // resolution or copying is needed here.
-  const tree = buildTree(sizedTools, { id: slug, name: domain.name });
+  const tree = buildTree(sizedProjects, { id: slug, name: domain.name });
 
   mkdirSync(`${DIST_DIR}/${slug}`, { recursive: true });
   mkdirSync(`${DIST_DIR}/embed/${slug}`, { recursive: true });

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -37,7 +37,7 @@ function renderShell({ title, ogTitle, ogDescription, ogImage, ogUrl, base, body
  * Renders a domain's full page (or its chrome-free embed variant, when
  * `embed` is true). `domain` is { slug, name, description }. `tree` is
  * buildTree's output; each leaf's `image` (when present) is already a
- * direct URL into the tool's source repo, ready to use as-is.
+ * direct URL into the project's source repo, ready to use as-is.
  */
 export function renderDomainPage(domain, tree, { embed = false, defaultOgImage, siteUrl = "", basePath = "" }) {
   const backLink = embed ? "" : `<p class="back-link"><a href="${basePath}/">&larr; All maps</a></p>`;
@@ -91,7 +91,7 @@ export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", baseP
       </div>
       <div class="hero-content">
         <h1>awesomemap</h1>
-        <p class="hero-tagline">Interactive, zoomable maps of open-source tool ecosystems — sized by adoption, explorable by category.</p>
+        <p class="hero-tagline">Interactive, zoomable maps of open-source project ecosystems — sized by adoption, explorable by category.</p>
       </div>
     </header>
     <div class="map-index">

--- a/scripts/snapshot-history.mjs
+++ b/scripts/snapshot-history.mjs
@@ -8,7 +8,7 @@ const HISTORY_DIR = "data/history";
 const MAX_AGE_DAYS = 120;
 
 /**
- * Inserts today's `{ date, stars }` snapshot into a tool's history array,
+ * Inserts today's `{ date, stars }` snapshot into a project's history array,
  * keeping entries sorted ascending by date. A snapshot sharing an existing
  * entry's date replaces that entry rather than duplicating it, so running
  * the job twice in one day is a no-op the second time.
@@ -33,7 +33,7 @@ function todayIso(now) {
 }
 
 // CLI entry point: node scripts/snapshot-history.mjs
-// Snapshots every tool in every data/<slug>.json into
+// Snapshots every project in every data/<slug>.json into
 // data/history/<slug>.json. Thin I/O orchestration, not unit tested (same
 // convention as generate.mjs / enrich-domain.mjs's main()) — verified
 // manually in Task 4.
@@ -55,20 +55,20 @@ async function main() {
 
     let fetched = 0;
     let failed = 0;
-    for (const tool of domain.tools) {
-      const repo = parseGhRepo(tool.id);
+    for (const project of domain.projects) {
+      const repo = parseGhRepo(project.id);
       if (!repo) continue;
       totalAttempted += 1;
       try {
         const repoData = await getJson(`https://api.github.com/repos/${repo.owner}/${repo.repo}`);
-        const existing = history[tool.id] ?? [];
+        const existing = history[project.id] ?? [];
         const withToday = appendSnapshotEntry(existing, { date: today, stars: repoData.stargazers_count });
-        history[tool.id] = pruneOldEntries(withToday, { now: new Date() });
+        history[project.id] = pruneOldEntries(withToday, { now: new Date() });
         fetched += 1;
         totalFetched += 1;
       } catch (err) {
         failed += 1;
-        console.error(`Warning: failed to snapshot "${tool.id}": ${err.message}`);
+        console.error(`Warning: failed to snapshot "${project.id}": ${err.message}`);
       }
     }
 
@@ -78,8 +78,8 @@ async function main() {
 
   if (totalAttempted > 0 && totalFetched === 0) {
     console.error(
-      `Error: 0/${totalAttempted} tool(s) were successfully snapshotted across all domains — ` +
-        "this looks like a systemic failure (e.g. an invalid/expired token or a GitHub outage), not isolated per-tool flakiness."
+      `Error: 0/${totalAttempted} project(s) were successfully snapshotted across all domains — ` +
+        "this looks like a systemic failure (e.g. an invalid/expired token or a GitHub outage), not isolated per-project flakiness."
     );
     process.exit(1);
   }

--- a/scripts/social-digest.mjs
+++ b/scripts/social-digest.mjs
@@ -9,14 +9,14 @@ const LIMIT = 5;
 
 /**
  * Computes the top star-growth risers across every domain for one
- * window. `domains` is `[{ slug, name, tools }]` (raw `data/*.json`
+ * window. `domains` is `[{ slug, name, projects }]` (raw `data/*.json`
  * shape); `historyBySlug` maps slug to that domain's
- * `data/history/<slug>.json` contents (`{ toolId: [{date, stars}] }`).
+ * `data/history/<slug>.json` contents (`{ projectId: [{date, stars}] }`).
  *
- * A tool can appear once per domain it's listed in (the same tool may be
- * curated into more than one map) — each listing is scored
- * independently since its history is keyed by tool id, not by
- * domain+tool. Only tools with `hasEnoughHistory` for the window are
+ * A project can appear once per domain it's listed in (the same project
+ * may be curated into more than one map) — each listing is scored
+ * independently since its history is keyed by project id, not by
+ * domain+project. Only projects with `hasEnoughHistory` for the window are
  * eligible, so the list is empty (not wrong) until enough daily
  * snapshots have accumulated.
  */
@@ -25,13 +25,13 @@ export function computeTopRisers(domains, historyBySlug, { windowDays = WINDOW_D
 
   for (const domain of domains) {
     const history = historyBySlug[domain.slug] ?? {};
-    for (const tool of domain.tools) {
-      const velocity = computeVelocity(history[tool.id] ?? [], windowDays, { now });
+    for (const project of domain.projects) {
+      const velocity = computeVelocity(history[project.id] ?? [], windowDays, { now });
       if (!velocity.hasEnoughHistory || velocity.starDelta <= 0) continue;
       candidates.push({
-        id: tool.id,
-        name: tool.name,
-        link: tool.link,
+        id: project.id,
+        name: project.name,
+        link: project.link,
         domain: domain.name,
         starDelta: velocity.starDelta,
         percentDelta: velocity.percentDelta,

--- a/scripts/velocity.mjs
+++ b/scripts/velocity.mjs
@@ -1,8 +1,8 @@
 export const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-// The lowest positive size a tool's rising score can ever be. d3's
+// The lowest positive size a project's rising score can ever be. d3's
 // treemap requires strictly positive weights, so a declining or
-// no-history tool still renders a (negligible) tile instead of vanishing
+// no-history project still renders a (negligible) tile instead of vanishing
 // or breaking layout.
 const SCORE_FLOOR = 0.01;
 
@@ -10,7 +10,7 @@ const SCORE_FLOOR = 0.01;
 export const RISING_WINDOWS_DAYS = [7, 30, 90];
 
 /**
- * Computes a growth-velocity score for one tool from its raw star-count
+ * Computes a growth-velocity score for one project from its raw star-count
  * history. `history` is an array of `{ date: "YYYY-MM-DD", stars }`
  * entries in any order; `windowDays` is how far back to measure growth.
  *
@@ -54,13 +54,13 @@ export function computeVelocity(history, windowDays, { now = new Date() } = {}) 
 
 /**
  * Builds the full `{ sizes, hasEnoughHistory, growth }` structure
- * `generate.mjs` embeds onto a tool's leaf node: one size per mode
+ * `generate.mjs` embeds onto a project's leaf node: one size per mode
  * (`popular` plus one `rising<N>` per supported window), whether each
  * rising window has enough history, and the growth stats behind each
  * rising size (used by the detail panel).
  */
-export function computeToolSizing(tool, historyEntries = [], { now } = {}) {
-  const sizes = { popular: typeof tool.weight === "number" ? tool.weight : 1 };
+export function computeProjectSizing(project, historyEntries = [], { now } = {}) {
+  const sizes = { popular: typeof project.weight === "number" ? project.weight : 1 };
   const hasEnoughHistory = {};
   const growth = {};
 
@@ -76,19 +76,19 @@ export function computeToolSizing(tool, historyEntries = [], { now } = {}) {
 }
 
 /**
- * Given tools that have already been through `computeToolSizing` (i.e.
- * each has a `sizes` object), returns the ids of any tool whose `sizes`
- * contains a non-numeric, non-finite, or non-positive value — a broken
- * tile should never reach production. Mirrors `enrich-domain.mjs`'s
+ * Given projects that have already been through `computeProjectSizing`
+ * (i.e. each has a `sizes` object), returns the ids of any project whose
+ * `sizes` contains a non-numeric, non-finite, or non-positive value — a
+ * broken tile should never reach production. Mirrors `enrich-domain.mjs`'s
  * `findInvalidWeights` for this feature's own `sizes` field.
  */
-export function findInvalidSizes(tools) {
+export function findInvalidSizes(projects) {
   const bad = [];
-  for (const tool of tools) {
-    const sizes = tool.sizes ?? {};
+  for (const project of projects) {
+    const sizes = project.sizes ?? {};
     const values = ["popular", ...RISING_WINDOWS_DAYS.map((d) => `rising${d}`)].map((key) => sizes[key]);
     const invalid = values.some((value) => typeof value !== "number" || !Number.isFinite(value) || value <= 0);
-    if (invalid) bad.push(tool.id);
+    if (invalid) bad.push(project.id);
   }
   return bad;
 }

--- a/test/build-tree.test.js
+++ b/test/build-tree.test.js
@@ -4,12 +4,12 @@ import { buildTree } from "../scripts/build-tree.mjs";
 
 const ROOT = { id: "data-science", name: "Data Science" };
 
-test("groups flat tools by shared single-level path", () => {
-  const tools = [
+test("groups flat projects by shared single-level path", () => {
+  const projects = [
     { id: "scikit-learn", path: ["Classic ML"], name: "SciKit Learn" },
     { id: "xgboost", path: ["Classic ML"], name: "XGBoost" },
   ];
-  const tree = buildTree(tools, ROOT);
+  const tree = buildTree(projects, ROOT);
   assert.equal(tree.children.length, 1);
   assert.equal(tree.children[0].name, "Classic ML");
   assert.deepEqual(
@@ -19,46 +19,46 @@ test("groups flat tools by shared single-level path", () => {
 });
 
 test("nests multi-level paths correctly", () => {
-  const tools = [{ id: "yolo", path: ["Deep Learning", "Computer Vision"], name: "YOLO" }];
-  const tree = buildTree(tools, ROOT);
+  const projects = [{ id: "yolo", path: ["Deep Learning", "Computer Vision"], name: "YOLO" }];
+  const tree = buildTree(projects, ROOT);
   assert.equal(tree.children[0].name, "Deep Learning");
   assert.equal(tree.children[0].children[0].name, "Computer Vision");
   assert.equal(tree.children[0].children[0].children[0].id, "yolo");
 });
 
-test("places a tool with an empty path directly under root", () => {
-  const tools = [{ id: "misc-tool", path: [], name: "Misc" }];
-  const tree = buildTree(tools, ROOT);
+test("places a project with an empty path directly under root", () => {
+  const projects = [{ id: "misc-project", path: [], name: "Misc" }];
+  const tree = buildTree(projects, ROOT);
   assert.equal(tree.children.length, 1);
-  assert.equal(tree.children[0].id, "misc-tool");
+  assert.equal(tree.children[0].id, "misc-project");
 });
 
-test("throws when a tool's path is not an array", () => {
-  const tools = [{ id: "bad-tool", path: "Classic ML" }];
-  assert.throws(() => buildTree(tools, ROOT), /Tool "bad-tool" has a non-array path/);
+test("throws when a project's path is not an array", () => {
+  const projects = [{ id: "bad-project", path: "Classic ML" }];
+  assert.throws(() => buildTree(projects, ROOT), /Project "bad-project" has a non-array path/);
 });
 
-test("produces a childless root for an empty tools array", () => {
+test("produces a childless root for an empty projects array", () => {
   const tree = buildTree([], ROOT);
   assert.deepEqual(tree, { id: "data-science", name: "Data Science", children: [] });
 });
 
 test("defaults a leaf's name to its id and desc to empty string when omitted", () => {
-  const tools = [{ id: "mystery-tool", path: ["Misc"] }];
-  const tree = buildTree(tools, ROOT);
+  const projects = [{ id: "mystery-project", path: ["Misc"] }];
+  const tree = buildTree(projects, ROOT);
   const leaf = tree.children[0].children[0];
-  assert.equal(leaf.name, "mystery-tool");
+  assert.equal(leaf.name, "mystery-project");
   assert.equal(leaf.desc, "");
 });
 
 test("does not leak the path field onto the built leaf node", () => {
-  const tools = [{ id: "scikit-learn", path: ["Classic ML"], name: "SciKit Learn" }];
-  const tree = buildTree(tools, ROOT);
+  const projects = [{ id: "scikit-learn", path: ["Classic ML"], name: "SciKit Learn" }];
+  const tree = buildTree(projects, ROOT);
   assert.equal(tree.children[0].children[0].path, undefined);
 });
 
 test("carries arbitrary extra leaf fields (e.g. sizes/hasEnoughHistory/growth) through unchanged", () => {
-  const tools = [
+  const projects = [
     {
       id: "scikit-learn",
       path: ["Classic ML"],
@@ -67,9 +67,9 @@ test("carries arbitrary extra leaf fields (e.g. sizes/hasEnoughHistory/growth) t
       growth: { rising7: { starDelta: 5, percentDelta: 5, oldestDate: "2026-08-01" } },
     },
   ];
-  const tree = buildTree(tools, ROOT);
+  const tree = buildTree(projects, ROOT);
   const leaf = tree.children[0].children[0];
-  assert.deepEqual(leaf.sizes, tools[0].sizes);
-  assert.deepEqual(leaf.hasEnoughHistory, tools[0].hasEnoughHistory);
-  assert.deepEqual(leaf.growth, tools[0].growth);
+  assert.deepEqual(leaf.sizes, projects[0].sizes);
+  assert.deepEqual(leaf.hasEnoughHistory, projects[0].hasEnoughHistory);
+  assert.deepEqual(leaf.growth, projects[0].growth);
 });

--- a/test/enrich-domain.test.js
+++ b/test/enrich-domain.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import {
   parseGhRepo,
   LOGO_CANDIDATE_PATHS,
-  enrichTool,
+  enrichProject,
   withRetry,
   defaultIsRetryable,
   createGetJson,
@@ -63,19 +63,19 @@ function fakeGetJson({ repoStars, contentsByPath }) {
   };
 }
 
-test("enrichTool sets weight from the repo's star count", async () => {
-  const tool = { id: "facebook/react" };
+test("enrichProject sets weight from the repo's star count", async () => {
+  const project = { id: "facebook/react" };
   const getJson = fakeGetJson({ repoStars: 12345, contentsByPath: {} });
 
-  const result = await enrichTool(tool, { getJson });
+  const result = await enrichProject(project, { getJson });
 
   assert.equal(result.weight, 12345);
   assert.equal(result.id, "facebook/react");
   assert.equal(result.image, undefined);
 });
 
-test("enrichTool sets image to the first matching logo candidate's direct URL", async () => {
-  const tool = { id: "facebook/react" };
+test("enrichProject sets image to the first matching logo candidate's direct URL", async () => {
+  const project = { id: "facebook/react" };
   const getJson = fakeGetJson({
     repoStars: 12345,
     contentsByPath: {
@@ -84,31 +84,31 @@ test("enrichTool sets image to the first matching logo candidate's direct URL", 
     },
   });
 
-  const result = await enrichTool(tool, { getJson });
+  const result = await enrichProject(project, { getJson });
 
   assert.equal(result.weight, 12345);
   assert.equal(result.image, "https://raw.githubusercontent.com/facebook/react/main/logo.png");
 });
 
-test("enrichTool leaves image unset when no candidate path exists", async () => {
-  const tool = { id: "facebook/react" };
+test("enrichProject leaves image unset when no candidate path exists", async () => {
+  const project = { id: "facebook/react" };
   const getJson = fakeGetJson({ repoStars: 12345, contentsByPath: {} });
 
-  const result = await enrichTool(tool, { getJson });
+  const result = await enrichProject(project, { getJson });
 
   assert.equal(result.weight, 12345);
   assert.equal(result.image, undefined);
 });
 
-test("enrichTool leaves a tool whose id isn't an owner/repo shorthand unchanged", async () => {
-  const tool = { id: "unlisted", desc: "no repo" };
+test("enrichProject leaves a project whose id isn't an owner/repo shorthand unchanged", async () => {
+  const project = { id: "unlisted", desc: "no repo" };
   const getJson = async () => {
     throw new Error("should not be called");
   };
 
-  const result = await enrichTool(tool, { getJson });
+  const result = await enrichProject(project, { getJson });
 
-  assert.deepEqual(result, tool);
+  assert.deepEqual(result, project);
 });
 
 function fakeSleep(calls) {
@@ -281,43 +281,43 @@ test("withRetry rejects attempts < 1 with a clear error instead of silently retu
 
 // findInvalidWeights: the post-enrichment guard that would have caught the
 // earlier draft of mobile-dev.json shipping with every weight stuck at 0.
-test("findInvalidWeights returns an empty list when every repo-linked tool has a valid weight", () => {
-  const tools = [
+test("findInvalidWeights returns an empty list when every repo-linked project has a valid weight", () => {
+  const projects = [
     { id: "facebook/react", weight: 12345 },
     { id: "vuejs/vue", weight: 1 },
     { id: "c", desc: "no repo at all" },
   ];
 
-  assert.deepEqual(findInvalidWeights(tools), []);
+  assert.deepEqual(findInvalidWeights(projects), []);
 });
 
-test("findInvalidWeights flags a repo-linked tool whose weight is 0", () => {
-  const tools = [
+test("findInvalidWeights flags a repo-linked project whose weight is 0", () => {
+  const projects = [
     { id: "facebook/react", weight: 12345 },
     { id: "zero-weight/repo", weight: 0 },
   ];
 
-  assert.deepEqual(findInvalidWeights(tools), ["zero-weight/repo"]);
+  assert.deepEqual(findInvalidWeights(projects), ["zero-weight/repo"]);
 });
 
-test("findInvalidWeights flags a repo-linked tool whose weight is undefined", () => {
-  const tools = [{ id: "no-weight/repo" }];
+test("findInvalidWeights flags a repo-linked project whose weight is undefined", () => {
+  const projects = [{ id: "no-weight/repo" }];
 
-  assert.deepEqual(findInvalidWeights(tools), ["no-weight/repo"]);
+  assert.deepEqual(findInvalidWeights(projects), ["no-weight/repo"]);
 });
 
-test("findInvalidWeights does not flag a tool whose id isn't an owner/repo shorthand, even without a weight", () => {
-  const tools = [{ id: "unlisted", desc: "no repo, never enriched, no weight expected" }];
+test("findInvalidWeights does not flag a project whose id isn't an owner/repo shorthand, even without a weight", () => {
+  const projects = [{ id: "unlisted", desc: "no repo, never enriched, no weight expected" }];
 
-  assert.deepEqual(findInvalidWeights(tools), []);
+  assert.deepEqual(findInvalidWeights(projects), []);
 });
 
 test("findInvalidWeights flags non-integer and negative weights too", () => {
-  const tools = [
+  const projects = [
     { id: "fractional/repo", weight: 4.5 },
     { id: "negative/repo", weight: -1 },
     { id: "not-a-number/repo", weight: "12345" },
   ];
 
-  assert.deepEqual(findInvalidWeights(tools), ["fractional/repo", "negative/repo", "not-a-number/repo"]);
+  assert.deepEqual(findInvalidWeights(projects), ["fractional/repo", "negative/repo", "not-a-number/repo"]);
 });

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -21,11 +21,11 @@ test("a domain description containing '$`' does not corrupt the page", () => {
   assert.doesNotMatch(html, /\{\{TITLE\}\}/);
 });
 
-test("a tool desc containing a literal '</script>' does not produce a raw '</script>' in the output", () => {
+test("a project desc containing a literal '</script>' does not produce a raw '</script>' in the output", () => {
   const tree = {
     id: "data-science",
     name: "Data Science",
-    children: [{ id: "evil-tool", name: "Evil Tool", desc: "</script><script>alert(1)</script>", children: [] }],
+    children: [{ id: "evil-project", name: "Evil Project", desc: "</script><script>alert(1)</script>", children: [] }],
   };
   const domain = { slug: "data-science", name: "Data Science", description: "desc" };
   const html = renderDomainPage(domain, tree, { defaultOgImage: "/og-default.png" });

--- a/test/social-digest.test.js
+++ b/test/social-digest.test.js
@@ -8,19 +8,19 @@ const DOMAINS = [
   {
     slug: "data-science",
     name: "Data Science",
-    tools: [
-      { id: "a/a", name: "Tool A", link: "https://a.example" },
-      { id: "b/b", name: "Tool B", link: "https://b.example" },
+    projects: [
+      { id: "a/a", name: "Project A", link: "https://a.example" },
+      { id: "b/b", name: "Project B", link: "https://b.example" },
     ],
   },
   {
     slug: "security",
     name: "Security",
-    tools: [{ id: "c/c", name: "Tool C", link: "https://c.example" }],
+    projects: [{ id: "c/c", name: "Project C", link: "https://c.example" }],
   },
 ];
 
-test("computeTopRisers ranks tools by star delta, descending, across domains", () => {
+test("computeTopRisers ranks projects by star delta, descending, across domains", () => {
   const history = {
     "data-science": {
       "a/a": [
@@ -48,7 +48,7 @@ test("computeTopRisers ranks tools by star delta, descending, across domains", (
   assert.equal(result[0].starDelta, 40);
 });
 
-test("computeTopRisers excludes tools without enough history for the window", () => {
+test("computeTopRisers excludes projects without enough history for the window", () => {
   const history = {
     "data-science": { "a/a": [{ date: "2026-08-14", stars: 100 }] },
     security: {},
@@ -57,7 +57,7 @@ test("computeTopRisers excludes tools without enough history for the window", ()
   assert.deepEqual(result, []);
 });
 
-test("computeTopRisers excludes tools that shrank or stayed flat", () => {
+test("computeTopRisers excludes projects that shrank or stayed flat", () => {
   const history = {
     "data-science": {
       "a/a": [
@@ -97,10 +97,10 @@ test("computeTopRisers respects the limit", () => {
 
 test("formatDigest renders a numbered list with links and percentages", () => {
   const body = formatDigest(
-    [{ id: "a/a", name: "Tool A", link: "https://a.example", domain: "Data Science", starDelta: 30, percentDelta: 30 }],
+    [{ id: "a/a", name: "Project A", link: "https://a.example", domain: "Data Science", starDelta: 30, percentDelta: 30 }],
     { windowDays: 7 }
   );
-  assert.match(body, /1\. \*\*\[Tool A\]\(https:\/\/a\.example\)\*\* \(Data Science\) — \+30 stars \(\+30\.0%\)/);
+  assert.match(body, /1\. \*\*\[Project A\]\(https:\/\/a\.example\)\*\* \(Data Science\) — \+30 stars \(\+30\.0%\)/);
   assert.match(body, /last 7 days/);
 });
 

--- a/test/velocity.test.js
+++ b/test/velocity.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { computeVelocity, computeToolSizing, findInvalidSizes, RISING_WINDOWS_DAYS } from "../scripts/velocity.mjs";
+import { computeVelocity, computeProjectSizing, findInvalidSizes, RISING_WINDOWS_DAYS } from "../scripts/velocity.mjs";
 
 const NOW = "2026-08-08T00:00:00.000Z";
 
@@ -79,13 +79,13 @@ test("computeVelocity treats a zero-star baseline as 0% growth rather than divid
   assert.equal(result.percentDelta, 0);
 });
 
-test("computeToolSizing builds sizes/hasEnoughHistory/growth for every rising window plus popular", () => {
-  const tool = { id: "a/a", weight: 1000 };
+test("computeProjectSizing builds sizes/hasEnoughHistory/growth for every rising window plus popular", () => {
+  const project = { id: "a/a", weight: 1000 };
   const history = [
     { date: "2026-05-10", stars: 700 }, // ~90 days before NOW
     { date: "2026-08-08", stars: 1000 },
   ];
-  const result = computeToolSizing(tool, history, { now: NOW });
+  const result = computeProjectSizing(project, history, { now: NOW });
 
   assert.equal(result.sizes.popular, 1000);
   for (const windowDays of RISING_WINDOWS_DAYS) {
@@ -96,23 +96,23 @@ test("computeToolSizing builds sizes/hasEnoughHistory/growth for every rising wi
   }
 });
 
-test("computeToolSizing defaults popular to 1 when the tool has no weight", () => {
-  const result = computeToolSizing({ id: "a/a" }, [], { now: NOW });
+test("computeProjectSizing defaults popular to 1 when the project has no weight", () => {
+  const result = computeProjectSizing({ id: "a/a" }, [], { now: NOW });
   assert.equal(result.sizes.popular, 1);
 });
 
-test("computeToolSizing marks every rising window as insufficient when there's no history at all", () => {
-  const result = computeToolSizing({ id: "a/a", weight: 5 }, [], { now: NOW });
+test("computeProjectSizing marks every rising window as insufficient when there's no history at all", () => {
+  const result = computeProjectSizing({ id: "a/a", weight: 5 }, [], { now: NOW });
   for (const windowDays of RISING_WINDOWS_DAYS) {
     assert.equal(result.hasEnoughHistory[`rising${windowDays}`], false);
   }
 });
 
-test("findInvalidSizes flags a tool with a non-positive or missing size, and leaves valid tools alone", () => {
-  const tools = [
+test("findInvalidSizes flags a project with a non-positive or missing size, and leaves valid projects alone", () => {
+  const projects = [
     { id: "good", sizes: { popular: 10, rising7: 0.5, rising30: 0.2, rising90: 0.1 } },
     { id: "bad-zero", sizes: { popular: 0, rising7: 1, rising30: 1, rising90: 1 } },
     { id: "bad-missing", sizes: { popular: 10, rising7: 1, rising30: 1 } },
   ];
-  assert.deepEqual(findInvalidSizes(tools), ["bad-zero", "bad-missing"]);
+  assert.deepEqual(findInvalidSizes(projects), ["bad-zero", "bad-missing"]);
 });


### PR DESCRIPTION
## Summary
Renames the catalog's leaf-item terminology from "tool" to "project" throughout the codebase — data schema, generator/enrichment scripts, tests, README, and CONTRIBUTING.md.

**Why:** the catalog spans frameworks, libraries, platforms, and services (React, AWS CLI, Falco, etc.), not just literal "tools." "Project" matches the existing `id = owner/repo` GitHub convention and reads naturally across all domains.

## Changes
- `data/*.json`: `"tools"` array key → `"projects"`; domain titles `"Best X Open Source Tools"` → `"... Open Source Projects"`
- `scripts/*.mjs`: renamed identifiers/JSDoc (`computeToolSizing` → `computeProjectSizing`, `enrichTool` → `enrichProject`, `tool`/`tools` vars, error messages)
- `README.md` / `CONTRIBUTING.md`: prose and the schema example
- `test/*.js`: updated to match

Free-text `desc` fields and category names (e.g. "Build Tools & Bundlers") that use "tool" as ordinary English describing what a project actually is were left untouched — renaming those would change meaning, not terminology.

## Testing
- `npm test` — all 110 tests pass
- `node scripts/generate.mjs` — builds cleanly; verified `dist/index.html` hero copy and `dist/data-science/index.html` `<title>` reflect the new wording