### PR TITLE
fix: refresh stale/archived entries in Data Science domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _Not enough star-history yet to compute 7-day growth — check back once daily s
 
 | Map | Description | Projects |
 | --- | --- | --- |
-| [Data Science](https://haggaishachar.github.io/awesomemap/data-science/) | Machine learning, deep learning, NLP, computer vision, and more. | 44 |
+| [Data Science](https://haggaishachar.github.io/awesomemap/data-science/) | Machine learning, deep learning, NLP, computer vision, and more. | 51 |
 | [Security](https://haggaishachar.github.io/awesomemap/security/) | Scanning, exploitation, SIEM, secrets management, forensics, and more. | 51 |
 | [Web Development](https://haggaishachar.github.io/awesomemap/web-dev/) | Frontend frameworks, build tools, styling, backend frameworks, and more. | 50 |
 | [Mobile Development](https://haggaishachar.github.io/awesomemap/mobile-dev/) | Cross-platform frameworks, native tooling, testing, state management, and more. | 46 |

--- a/data/data-science.json
+++ b/data/data-science.json
@@ -4,6 +4,39 @@
   "description": "Machine learning, deep learning, NLP, computer vision, and more.",
   "projects": [
     {
+      "id": "pandas-dev/pandas",
+      "path": [
+        "Data Manipulation & Analysis"
+      ],
+      "link": "https://pandas.pydata.org/",
+      "name": "pandas",
+      "desc": "Flexible and powerful data analysis and manipulation library for Python",
+      "weight": 49517,
+      "image": "https://avatars.githubusercontent.com/u/21206976?v=4"
+    },
+    {
+      "id": "numpy/numpy",
+      "path": [
+        "Data Manipulation & Analysis"
+      ],
+      "link": "https://numpy.org/",
+      "name": "NumPy",
+      "desc": "The fundamental package for array computing in Python",
+      "weight": 32531,
+      "image": "https://avatars.githubusercontent.com/u/288276?v=4"
+    },
+    {
+      "id": "pola-rs/polars",
+      "path": [
+        "Data Manipulation & Analysis"
+      ],
+      "link": "https://pola.rs/",
+      "name": "Polars",
+      "desc": "Blazingly fast DataFrame library implemented in Rust",
+      "weight": 39348,
+      "image": "https://avatars.githubusercontent.com/u/83768144?v=4"
+    },
+    {
       "id": "scikit-learn/scikit-learn",
       "path": [
         "Classic Machine Learning"
@@ -11,7 +44,7 @@
       "link": "https://scikit-learn.org/stable/",
       "name": "SciKit Learn",
       "desc": "Machine Learning in Python",
-      "weight": 66965,
+      "weight": 66973,
       "image": "https://raw.githubusercontent.com/scikit-learn/scikit-learn/main/doc/logos/scikit-learn-logo.png"
     },
     {
@@ -22,7 +55,7 @@
       "link": "https://xgboost.ai/",
       "name": "XGBoost",
       "desc": "Scalable and Flexible Gradient Boosting",
-      "weight": 28647,
+      "weight": 28650,
       "image": "https://xgboost.ai/images/logo/xgboost-logo-trimmed.png"
     },
     {
@@ -37,6 +70,28 @@
       "image": "https://avatars.githubusercontent.com/u/5102613?v=4"
     },
     {
+      "id": "lightgbm-org/LightGBM",
+      "path": [
+        "Classic Machine Learning"
+      ],
+      "link": "https://lightgbm.readthedocs.io/",
+      "name": "LightGBM",
+      "desc": "A fast, distributed, high-performance gradient boosting framework",
+      "weight": 18680,
+      "image": "https://avatars.githubusercontent.com/u/266222920?v=4"
+    },
+    {
+      "id": "catboost/catboost",
+      "path": [
+        "Classic Machine Learning"
+      ],
+      "link": "https://catboost.ai/",
+      "name": "CatBoost",
+      "desc": "A fast, scalable, high-performance gradient boosting library",
+      "weight": 9066,
+      "image": "https://avatars.githubusercontent.com/u/29043415?v=4"
+    },
+    {
       "id": "tensorflow/tensorflow",
       "path": [
         "Deep Learning"
@@ -44,11 +99,11 @@
       "link": "https://www.tensorflow.org/",
       "name": "TensorFlow",
       "desc": "An end-to-end open source machine learning platform",
-      "weight": 196978,
+      "weight": 196997,
       "image": "https://www.tensorflow.org/images/tf_logo_horizontal.png"
     },
     {
-      "id": "deepmind/sonnet",
+      "id": "google-deepmind/sonnet",
       "path": [
         "Deep Learning"
       ],
@@ -66,19 +121,30 @@
       "link": "https://pytorch.org/",
       "name": "PyTorch",
       "desc": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
-      "weight": 102349,
+      "weight": 102358,
       "image": "https://raw.githubusercontent.com/pytorch/pytorch/main/docs/source/_static/img/pytorch-logo-dark.png"
     },
     {
-      "id": "apache/incubator-mxnet",
+      "id": "keras-team/keras",
       "path": [
         "Deep Learning"
       ],
-      "link": "https://mxnet.apache.org/",
-      "name": "MXNet",
-      "desc": "Lightweight, Portable, Flexible Distributed/Mobile Deep Learning",
-      "weight": 20812,
-      "image": "https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/mxnet_logo_2.png"
+      "link": "https://keras.io/",
+      "name": "Keras",
+      "desc": "Multi-backend deep learning framework for TensorFlow, JAX, and PyTorch",
+      "weight": 64226,
+      "image": "https://avatars.githubusercontent.com/u/34455048?v=4"
+    },
+    {
+      "id": "jax-ml/jax",
+      "path": [
+        "Deep Learning"
+      ],
+      "link": "https://docs.jax.dev/",
+      "name": "JAX",
+      "desc": "Composable transformations of Python+NumPy programs: differentiate, vectorize, JIT",
+      "weight": 36154,
+      "image": "https://avatars.githubusercontent.com/u/58486408?v=4"
     },
     {
       "id": "eclipse/deeplearning4j",
@@ -92,15 +158,15 @@
       "image": "https://www.zeljkoobrenovic.com/tools/tech/images/eclipse_deeplearning4j.png"
     },
     {
-      "id": "openai/gym",
+      "id": "Farama-Foundation/Gymnasium",
       "path": [
         "Reinforment Learning"
       ],
-      "link": "https://gym.openai.com/",
-      "name": "Gym",
-      "desc": "A toolkit for developing and comparing reinforcement learning algorithms",
-      "weight": 37242,
-      "image": "https://gymlibrary.dev/assets/gym_logo_black.svg"
+      "link": "https://gymnasium.farama.org/",
+      "name": "Gymnasium",
+      "desc": "A standard API for reinforcement learning, maintained successor to OpenAI Gym",
+      "weight": 12315,
+      "image": "https://avatars.githubusercontent.com/u/62961550?v=4"
     },
     {
       "id": "google/dopamine",
@@ -121,19 +187,19 @@
       "link": "https://reagent.ai/",
       "name": "ReAgent",
       "desc": "A platform for Reasoning systems (Reinforcement Learning, Contextual Bandits, etc.)",
-      "weight": 3709,
+      "weight": 3710,
       "image": "https://raw.githubusercontent.com/facebookresearch/ReAgent/main/logo/reagent_banner.png"
     },
     {
-      "id": "tensorlayer/tensorlayer",
+      "id": "DLR-RM/stable-baselines3",
       "path": [
         "Reinforment Learning"
       ],
-      "link": "http://tensorlayer.org",
-      "name": "Tensorlayer",
-      "desc": "Deep Learning and Reinforcement Learning Library for Scientists",
-      "weight": 7385,
-      "image": "https://raw.githubusercontent.com/tensorlayer/tensorlayer/master/img/tl_transparent_logo.png"
+      "link": "https://stable-baselines3.readthedocs.io/",
+      "name": "Stable-Baselines3",
+      "desc": "Reliable implementations of reinforcement learning algorithms in PyTorch",
+      "weight": 13685,
+      "image": "https://avatars.githubusercontent.com/u/25227811?v=4"
     },
     {
       "id": "google-research/bert",
@@ -154,7 +220,7 @@
       "link": "https://huggingface.co/transformers/",
       "name": "Transformers",
       "desc": "State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch",
-      "weight": 164008,
+      "weight": 164062,
       "image": "https://huggingface.co/datasets/huggingface/documentation-images/raw/main/transformers-logo-light.svg"
     },
     {
@@ -187,7 +253,7 @@
       "link": "https://spacy.io",
       "name": "spaCy",
       "desc": "Industrial-Strength Natural Language Processing",
-      "weight": 33812,
+      "weight": 33815,
       "image": "https://raw.githubusercontent.com/explosion/spaCy/master/website/src/images/icon.png"
     },
     {
@@ -198,7 +264,7 @@
       "link": "https://fasttext.cc",
       "name": "fastText",
       "desc": "Library for efficient text classification and representation learning",
-      "weight": 26541,
+      "weight": 26540,
       "image": "https://fasttext.cc/img/fasttext-logo-color-web.png"
     },
     {
@@ -220,7 +286,7 @@
       "link": "https://github.com/mozilla/DeepSpeech",
       "name": "DeepSpeech",
       "desc": "A TensorFlow implementation of Baidu's DeepSpeech architecture",
-      "weight": 26773,
+      "weight": 26774,
       "image": "https://avatars.githubusercontent.com/u/131524?v=4"
     },
     {
@@ -253,7 +319,7 @@
       "link": "https://opencv.org/",
       "name": "OpenCV",
       "desc": "Open Source Computer Vision Library",
-      "weight": 90396,
+      "weight": 90411,
       "image": "https://opencv.org/wp-content/uploads/2022/07/OpenCV-logo.png"
     },
     {
@@ -275,7 +341,7 @@
       "link": "https://github.com/CMU-Perceptual-Computing-Lab/openpose",
       "name": "OpenPose",
       "desc": "Real-time multi-person keypoint detection library for body, face, hands, and foot estimation",
-      "weight": 34360,
+      "weight": 34362,
       "image": "https://raw.githubusercontent.com/CMU-Perceptual-Computing-Lab/openpose/master/.github/Logo_main_black.png"
     },
     {
@@ -297,7 +363,7 @@
       "link": "https://spark.apache.org/mllib/",
       "name": "Spark MLlib",
       "desc": "Apache Spark's scalable machine learning library.",
-      "weight": 43856,
+      "weight": 43866,
       "image": "https://spark.apache.org/images/spark-logo-rev.svg"
     },
     {
@@ -341,7 +407,7 @@
       "link": "https://ray.io/",
       "name": "Ray",
       "desc": "A fast and simple framework for building and running distributed applications",
-      "weight": 43503,
+      "weight": 43509,
       "image": "https://raw.githubusercontent.com/ray-project/ray/master/doc/source/images/ray_header_logo.png"
     },
     {
@@ -352,7 +418,7 @@
       "link": "https://epistasislab.github.io/tpot/",
       "name": "TPOT",
       "desc": "A Python Automated Machine Learning.",
-      "weight": 10049,
+      "weight": 10051,
       "image": "https://raw.githubusercontent.com/EpistasisLab/tpot/master/images/tpot-logo.jpg"
     },
     {
@@ -363,11 +429,11 @@
       "link": "https://autokeras.com/",
       "name": "AutoKeras",
       "desc": "Accessible AutoML for deep learning.",
-      "weight": 9327,
+      "weight": 9328,
       "image": "https://autokeras.com/img/row_red.svg"
     },
     {
-      "id": "FeatureLabs/featuretools",
+      "id": "alteryx/featuretools",
       "path": [
         "AutoML"
       ],
@@ -378,26 +444,26 @@
       "image": "https://featuretools.alteryx.com/en/stable/_static/featuretools_nav2.svg"
     },
     {
-      "id": "microsoft/nni",
+      "id": "optuna/optuna",
       "path": [
         "AutoML"
       ],
-      "link": "https://github.com/microsoft/nni",
-      "name": "NNI",
-      "desc": "An open source AutoML toolkit for neural nets hyper-parameter tuning.",
-      "weight": 14365,
-      "image": "https://raw.githubusercontent.com/microsoft/nni/master/docs/img/nni_logo.png"
+      "link": "https://optuna.org/",
+      "name": "Optuna",
+      "desc": "A hyperparameter optimization framework",
+      "weight": 14657,
+      "image": "https://avatars.githubusercontent.com/u/57251745?v=4"
     },
     {
-      "id": "tensorflow/adanet",
+      "id": "autogluon/autogluon",
       "path": [
         "AutoML"
       ],
-      "link": "https://adanet.readthedocs.io",
-      "name": "AdaNet",
-      "desc": "Fast and flexible AutoML with learning guarantees",
-      "weight": 3454,
-      "image": "https://tensorflow.github.io/adanet/images/adanet_tangram_logo.png"
+      "link": "https://auto.gluon.ai/",
+      "name": "AutoGluon",
+      "desc": "Fast and accurate ML AutoML for text, image, tabular, and time series data",
+      "weight": 10595,
+      "image": "https://avatars.githubusercontent.com/u/92389699?v=4"
     },
     {
       "id": "jupyter/jupyter",
@@ -440,7 +506,7 @@
       "link": "https://www.h2o.ai/",
       "name": "H2O",
       "desc": "Fast Scalable Machine Learning For Smarter Applications",
-      "weight": 7504,
+      "weight": 7505,
       "image": "https://www.h2o.ai/content/experience-fragments/h2o/us/en/site/header/master/_jcr_content/root/container/header_copy/logo.coreimg.svg/1782337746232/h2o-logo.svg"
     },
     {
@@ -451,7 +517,7 @@
       "link": "https://mlflow.org/",
       "name": "MLflow",
       "desc": "An open source platform for the machine learning lifecycle",
-      "weight": 27487,
+      "weight": 27502,
       "image": "https://raw.githubusercontent.com/mlflow/mlflow/master/assets/logo.svg"
     },
     {
@@ -462,8 +528,19 @@
       "link": "https://www.kubeflow.org/",
       "name": "Kubeflow",
       "desc": "The Machine Learning Toolkit for Kubernetes",
-      "weight": 15811,
+      "weight": 15812,
       "image": "https://raw.githubusercontent.com/kubeflow/kubeflow/master/logo/stacked.svg"
+    },
+    {
+      "id": "wandb/wandb",
+      "path": [
+        "Platforms"
+      ],
+      "link": "https://wandb.ai/",
+      "name": "Weights & Biases",
+      "desc": "The AI developer platform for experiment tracking and model management",
+      "weight": 11230,
+      "image": "https://raw.githubusercontent.com/wandb/wandb/main/assets/logo.svg"
     },
     {
       "id": "onnx/onnx",
@@ -473,7 +550,7 @@
       "link": "https://onnx.ai/",
       "name": "ONNX",
       "desc": "The open ecosystem for interchangeable AI models.",
-      "weight": 21300,
+      "weight": 21304,
       "image": "https://raw.githubusercontent.com/onnx/onnx/main/docs/onnx-horizontal-color.png"
     },
     {


### PR DESCRIPTION
## Summary
Audit found the Data Science map missing pandas and NumPy entirely (arguably the two most-used libraries in the field) and carrying several entries that are now archived or effectively abandoned. This fixes both.

## Changes
Verified every changed entry's `archived` flag and last-push date via the GitHub API before touching it — see commit body for the full per-entry rationale.

- **New "Data Manipulation & Analysis" category**: pandas, NumPy, Polars
- **Classic Machine Learning**: + LightGBM, CatBoost
- **Deep Learning**: `apache/incubator-mxnet` → confirmed archived (redirects to `apache/mxnet`, also archived) → replaced with Keras; added JAX; fixed Sonnet's id to its current org (`google-deepmind/sonnet`, confirmed still active)
- **Reinforcement Learning**: `openai/gym` → confirmed archived, superseded → replaced with Gymnasium; `tensorlayer/tensorlayer` → confirmed no commits since Feb 2023 → replaced with Stable-Baselines3
- **AutoML**: removed `microsoft/nni` and `tensorflow/adanet` (both confirmed archived); fixed Featuretools' id to its current org (`alteryx/featuretools`); added Optuna, AutoGluon
- **Platforms**: + Weights & Biases

## Verification
- `node scripts/enrich-domain.mjs data/data-science.json` — 51/51 weights fetched, 0 failed.
- Checked for id collisions against all other domain files — none.
- `npm run generate` — builds all 7 domains cleanly.
- `npm test` — all 123 tests pass.
- README's Maps table project count updated (44 → 51).

🤖 Generated with [Claude Code](https://claude.com/claude-code)