### PR TITLE
feat: make the treemap stage responsive/mobile-friendly

### DIFF
--- a/app/shared/layout.js
+++ b/app/shared/layout.js
@@ -1,5 +1,38 @@
 import { hierarchy, treemap, treemapSquarify } from "d3-hierarchy";
 
+// The stage never grows past this width, regardless of viewport — the
+// original fixed desktop size, now a ceiling rather than the only size.
+const STAGE_MAX_WIDTH = 1000;
+// Reserved on each side so a box's outer edge never renders flush against
+// the screen edge on a narrow viewport.
+const STAGE_SIDE_MARGIN_PX = 16;
+// Below this *stage* width (after the side margin above is subtracted),
+// switch from the desktop landscape ratio to a taller, portrait-friendly
+// one — a phone-width stage would otherwise just be a short, squished
+// version of the desktop shape instead of making use of a tall screen.
+const STAGE_MOBILE_BREAKPOINT_PX = 640;
+const STAGE_MOBILE_HEIGHT_RATIO = 1.3;
+const STAGE_DESKTOP_HEIGHT_RATIO = 0.6; // matches the original 1000x600.
+
+/**
+ * Computes the stage's `{width, height}` from the width available to it
+ * (typically its container's `clientWidth`). Width is capped at
+ * `STAGE_MAX_WIDTH`; below `STAGE_MOBILE_BREAKPOINT_PX` the height uses a
+ * taller ratio than the desktop default so a phone-width stage makes
+ * better use of a portrait screen. Called once at mount and again on
+ * every resize/orientation change (see `mountTreemap`'s `resizeStage` in
+ * `treemap.js`) — this is the only place stage size is decided.
+ */
+export function computeStageSize(containerWidth) {
+  const usable = Math.max(0, containerWidth - STAGE_SIDE_MARGIN_PX * 2);
+  const width = Math.min(usable, STAGE_MAX_WIDTH);
+  const height =
+    width < STAGE_MOBILE_BREAKPOINT_PX
+      ? width * STAGE_MOBILE_HEIGHT_RATIO
+      : width * STAGE_DESKTOP_HEIGHT_RATIO;
+  return { width, height };
+}
+
 /**
  * Value accessor used by d3's hierarchy.sum(). Category nodes (nodes with
  * children) contribute nothing of their own — their size comes entirely

--- a/app/shared/treemap.js
+++ b/app/shared/treemap.js
@@ -1,7 +1,8 @@
-import { buildHierarchy, computeLevelBoxes } from "./layout.js";
+import { buildHierarchy, computeLevelBoxes, computeStageSize } from "./layout.js";
 
-const STAGE_WIDTH = 1000;
-const STAGE_HEIGHT = 600;
+// Debounce for the ResizeObserver in mountTreemap — avoids re-laying-out
+// the whole stage on every intermediate frame of a window drag-resize.
+const RESIZE_DEBOUNCE_MS = 150;
 // Deliberately duplicated from scripts/velocity.mjs's RISING_WINDOWS_DAYS
 // rather than imported: scripts/ is a build-time-only Node directory that
 // generate.mjs never copies into dist/, so this browser module can't
@@ -54,6 +55,9 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
   let focusNode = root;
   let focusIdPath = [root.data.id];
 
+  let stageWidth;
+  let stageHeight;
+
   container.innerHTML = "";
   const modeBar = document.createElement("div");
   modeBar.className = "treemap-mode-bar";
@@ -61,11 +65,25 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
   breadcrumb.className = "treemap-breadcrumb";
   const stage = document.createElement("div");
   stage.className = "treemap-stage";
-  stage.style.width = `${STAGE_WIDTH}px`;
-  stage.style.height = `${STAGE_HEIGHT}px`;
   container.appendChild(modeBar);
   container.appendChild(breadcrumb);
   container.appendChild(stage);
+
+  /**
+   * Applies a freshly computed `{width, height}` to the stage element and
+   * to the closure-scoped `stageWidth`/`stageHeight` that `renderLevel`
+   * lays boxes out against. Doesn't itself re-render — callers that need
+   * the new size reflected in the actual boxes call `renderLevel()` (or
+   * the full initial render sequence) afterwards.
+   */
+  function applyStageSize(size) {
+    stageWidth = size.width;
+    stageHeight = size.height;
+    stage.style.width = `${stageWidth}px`;
+    stage.style.height = `${stageHeight}px`;
+  }
+
+  applyStageSize(computeStageSize(container.clientWidth));
 
   function activeSizeKey() {
     return sizeMode === "popular" ? "popular" : `rising${risingWindow}`;
@@ -198,8 +216,8 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
     const boxes = computeLevelBoxes(focusNode.children, {
       focusId: focusNode.data.id,
       sizeKey: activeSizeKey(),
-      stageWidth: STAGE_WIDTH,
-      stageHeight: STAGE_HEIGHT,
+      stageWidth,
+      stageHeight,
       minBoxAreaPx: MIN_BOX_AREA_PX,
     });
     for (const box of boxes) {
@@ -395,6 +413,29 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
   renderModeBar();
   renderBreadcrumb();
   renderLevel();
+
+  /**
+   * Recomputes the stage size from the container's current width and,
+   * only if it actually changed, applies it and re-lays-out the current
+   * focus level. Zoom state (`focusNode`/`focusIdPath`) is untouched, so
+   * the user stays at whatever level they'd zoomed to across a resize.
+   */
+  function resizeStage() {
+    const nextSize = computeStageSize(container.clientWidth);
+    if (nextSize.width === stageWidth && nextSize.height === stageHeight) return;
+    applyStageSize(nextSize);
+    renderLevel();
+  }
+
+  let resizeTimeoutId = null;
+  const resizeObserver = new ResizeObserver(() => {
+    if (resizeTimeoutId !== null) clearTimeout(resizeTimeoutId);
+    resizeTimeoutId = setTimeout(() => {
+      resizeTimeoutId = null;
+      resizeStage();
+    }, RESIZE_DEBOUNCE_MS);
+  });
+  resizeObserver.observe(container);
 
   return { zoomTo, root };
 }

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -8,6 +8,7 @@ import {
   selectTopWithOthers,
   buildOthersNode,
   computeLevelBoxes,
+  computeStageSize,
 } from "../app/shared/layout.js";
 
 test("weightOf returns the leaf's weight when present", () => {
@@ -298,4 +299,45 @@ test("computeLevelBoxes passes every child through with no Others box exactly at
   });
   assert.equal(boxes.length, 3);
   assert.ok(boxes.every((box) => box.kind === "real"));
+});
+
+test("computeStageSize reproduces the legacy 1000x600 size when the container is exactly wide enough", () => {
+  // 1032 - 16*2 (side margins) = 1000 = STAGE_MAX_WIDTH exactly.
+  const size = computeStageSize(1032);
+  assert.equal(size.width, 1000);
+  assert.equal(size.height, 600);
+});
+
+test("computeStageSize caps width at 1000 for a container much wider than the max", () => {
+  const size = computeStageSize(2000);
+  assert.equal(size.width, 1000);
+  assert.equal(size.height, 600);
+});
+
+test("computeStageSize uses the desktop ratio exactly at the mobile breakpoint", () => {
+  // 672 - 16*2 = 640 = STAGE_MOBILE_BREAKPOINT_PX exactly — not below it,
+  // so this is still the desktop ratio, not the mobile one.
+  const size = computeStageSize(672);
+  assert.equal(size.width, 640);
+  assert.equal(size.height, 640 * 0.6);
+});
+
+test("computeStageSize switches to the taller mobile ratio just below the breakpoint", () => {
+  // 671 - 16*2 = 639, just under STAGE_MOBILE_BREAKPOINT_PX.
+  const size = computeStageSize(671);
+  assert.equal(size.width, 639);
+  assert.equal(size.height, 639 * 1.3);
+});
+
+test("computeStageSize fits a typical phone-width container with the mobile ratio", () => {
+  // 375 - 16*2 = 343.
+  const size = computeStageSize(375);
+  assert.equal(size.width, 343);
+  assert.equal(size.height, 343 * 1.3);
+});
+
+test("computeStageSize never goes negative for a container narrower than the side margins", () => {
+  const size = computeStageSize(10);
+  assert.equal(size.width, 0);
+  assert.equal(size.height, 0);
 });


### PR DESCRIPTION
## Summary

The treemap stage was a hardcoded 1000×600px canvas, which overflowed horizontally on any viewport narrower than 1000px — confirmed live on the deployed site at 375px width (`document.body.scrollWidth` pinned to 1000, forcing horizontal scroll / pinch-zoom on phones).

- Adds a pure `computeStageSize(containerWidth)` function (`app/shared/layout.js`) that caps stage width at 1000px and switches to a taller, portrait-friendly aspect ratio below a 640px breakpoint, so phones make better use of their screen instead of getting a squished landscape strip.
- Wires it into `mountTreemap()` (`app/shared/treemap.js`): dynamic sizing at mount, plus a debounced `ResizeObserver` that re-fits the stage live on window resize / phone rotation without resetting zoom state.
- No visual change at desktop widths ≥1032px (pixel-identical 1000×600 stage). Behavior only changes below that, where it was broken before.

## Testing

- `npm test`: 101/101 passing (95 pre-existing + 6 new `computeStageSize` unit tests).
- Manually verified in-browser at 375×812 and 1280×800: no horizontal overflow, correct mobile aspect ratio (343×446 stage), category zoom / leaf click / detail panel all working, container resize genuinely propagates.

## Process

Built via brainstorming → design spec → implementation plan → subagent-driven execution (2 tasks, each independently reviewed clean) → final whole-branch review (opus, verdict: **Ready to merge: Yes**, no Critical/Important findings).

5 Minor items were surfaced by the final review and deliberately deferred as follow-ups rather than blocking this PR (none affect correctness):
1. Rare `ResizeObserver` scrollbar-toggle flicker in a narrow height band below 1032px container width (`scrollbar-gutter: stable` fixes it).
2. Mode bar / breadcrumb / back-link sit flush against the screen edge on phones while the stage has a 16px inset (out of this change's scope per the design spec's non-goals).
3. Resize/rotate can drop DOM focus off a peek tile — pre-existing behavior on zoom/mode-switch too, just newly reachable via resize.
4. No `ResizeObserver.disconnect()` teardown path — not exploitable today (`mountTreemap` has exactly one call site, no remount path).
5. Test coverage gap: the spec's own desktop worked example (`computeStageSize(1000) → {968, 580.8}`) isn't pinned as its own test case.

Design spec: `docs/superpowers/specs/2026-08-13-mobile-responsive-treemap-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-13-mobile-responsive-treemap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)