### PR TITLE
fix: drop stale User-avatar icon for Superpowers

### DIFF
--- a/data/artificial-intelligence.json
+++ b/data/artificial-intelligence.json
@@ -432,8 +432,7 @@
       "link": "https://github.com/obra/superpowers",
       "name": "Superpowers",
       "desc": "An agentic skills framework & software development methodology that works",
-      "weight": 271633,
-      "image": "https://avatars.githubusercontent.com/u/45416?v=4"
+      "weight": 271633
     },
     {
       "id": "meta-llama/llama",


### PR DESCRIPTION
## Summary
- \`obra/superpowers\` was showing the repo owner's personal GitHub avatar (a face photo) as its project icon.
- \`obra\` is a GitHub **User**, not an Organization, and the repo has no dedicated logo file, so per the rule added in #9 this project should carry no \`image\` and fall back to the generic tile.
- This entry predates that rule and wasn't re-enriched when #9 merged (that PR only touched history snapshots for this domain, not the live data file).

## Test plan
- [x] \`npm test\` — 126/126 passing
- [x] JSON validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)