### PR TITLE
fix: sweep remaining stale User-avatar icons across all domains

### DIFF
--- a/data/artificial-intelligence.json
+++ b/data/artificial-intelligence.json
@@ -491,8 +491,7 @@
       "link": "https://localai.io/",
       "name": "LocalAI",
       "desc": "Self-hosted, OpenAI API-compatible drop-in replacement for local inference",
-      "weight": 48421,
-      "image": "https://avatars.githubusercontent.com/u/2420543?v=4"
+      "weight": 48421
     },
     {
       "id": "oobabooga/text-generation-webui",
@@ -503,8 +502,7 @@
       "link": "https://github.com/oobabooga/text-generation-webui",
       "name": "Text Generation WebUI",
       "desc": "A Gradio web UI for running local large language models",
-      "weight": 47543,
-      "image": "https://avatars.githubusercontent.com/u/112222186?v=4"
+      "weight": 47543
     },
     {
       "id": "nomic-ai/gpt4all",

--- a/data/data-science.json
+++ b/data/data-science.json
@@ -352,8 +352,7 @@
       "link": "https://github.com/davidsandberg/facenet",
       "name": "facenet",
       "desc": "Face recognition using Tensorflow",
-      "weight": 14349,
-      "image": "https://avatars.githubusercontent.com/u/15169058?v=4"
+      "weight": 14349
     },
     {
       "id": "apache/spark",

--- a/data/databases.json
+++ b/data/databases.json
@@ -33,8 +33,7 @@
       "link": "https://www.sqlite.org/",
       "name": "SQLite",
       "desc": "Official Git mirror of the SQLite source tree",
-      "weight": 10254,
-      "image": "https://avatars.githubusercontent.com/u/48680494?v=4"
+      "weight": 10254
     },
     {
       "id": "cockroachdb/cockroach",
@@ -440,8 +439,7 @@
       "link": "https://www.adminer.org/",
       "name": "Adminer",
       "desc": "Database management in a single PHP file",
-      "weight": 7752,
-      "image": "https://avatars.githubusercontent.com/u/117453?v=4"
+      "weight": 7752
     },
     {
       "id": "flyway/flyway",

--- a/data/mobile-dev.json
+++ b/data/mobile-dev.json
@@ -154,8 +154,7 @@
       "link": "https://github.com/onevcat/Kingfisher",
       "name": "Kingfisher",
       "desc": "A lightweight, pure-Swift library for downloading and caching images from the web",
-      "weight": 24390,
-      "image": "https://avatars.githubusercontent.com/u/1019875?v=4"
+      "weight": 24390
     },
     {
       "id": "SDWebImage/SDWebImage",
@@ -374,8 +373,7 @@
       "link": "https://riverpod.dev/",
       "name": "Riverpod",
       "desc": "A reactive caching and data-binding framework for Flutter and Dart",
-      "weight": 7365,
-      "image": "https://avatars.githubusercontent.com/u/20165741?v=4"
+      "weight": 7365
     },
     {
       "id": "felangel/bloc",
@@ -385,8 +383,7 @@
       "link": "https://bloclibrary.dev/",
       "name": "Bloc",
       "desc": "A predictable state management library implementing the BLoC pattern for Flutter and Dart",
-      "weight": 12483,
-      "image": "https://avatars.githubusercontent.com/u/8855632?v=4"
+      "weight": 12483
     },
     {
       "id": "react-navigation/react-navigation",
@@ -418,8 +415,7 @@
       "link": "https://pub.dev/packages/auto_route",
       "name": "AutoRoute",
       "desc": "A declarative, type-safe route generator for Flutter",
-      "weight": 1752,
-      "image": "https://avatars.githubusercontent.com/u/55059449?v=4"
+      "weight": 1752
     },
     {
       "id": "fastlane/fastlane",

--- a/data/security.json
+++ b/data/security.json
@@ -22,8 +22,7 @@
       "link": "https://github.com/robertdavidgraham/masscan",
       "name": "Masscan",
       "desc": "TCP port scanner that spews SYN packets asynchronously, scanning the entire Internet in under 5 minutes",
-      "weight": 25927,
-      "image": "https://avatars.githubusercontent.com/u/3814757?v=4"
+      "weight": 25927
     },
     {
       "id": "zmap/zmap",
@@ -55,8 +54,7 @@
       "link": "https://github.com/lanmaster53/recon-ng",
       "name": "Recon-ng",
       "desc": "Open source intelligence gathering tool aimed at reducing the time spent harvesting information from open sources",
-      "weight": 5846,
-      "image": "https://avatars.githubusercontent.com/u/2516395?v=4"
+      "weight": 5846
     },
     {
       "id": "laramies/theHarvester",
@@ -66,8 +64,7 @@
       "link": "https://github.com/laramies/theHarvester",
       "name": "theHarvester",
       "desc": "E-mails, subdomains and names harvester - OSINT reconnaissance tool",
-      "weight": 17023,
-      "image": "https://avatars.githubusercontent.com/u/543611?v=4"
+      "weight": 17023
     },
     {
       "id": "greenbone/openvas-scanner",
@@ -88,8 +85,7 @@
       "link": "https://cirt.net/Nikto2",
       "name": "Nikto",
       "desc": "Web server scanner that tests for dangerous files, outdated software, and other vulnerabilities",
-      "weight": 10645,
-      "image": "https://avatars.githubusercontent.com/u/1474884?v=4"
+      "weight": 10645
     },
     {
       "id": "projectdiscovery/nuclei",
@@ -143,8 +139,7 @@
       "link": "https://dalfox.hahwul.com/",
       "name": "Dalfox",
       "desc": "Powerful open source XSS scanner and parameter analysis tool focused on automation",
-      "weight": 5224,
-      "image": "https://avatars.githubusercontent.com/u/13212227?v=4"
+      "weight": 5224
     },
     {
       "id": "xmendez/wfuzz",
@@ -154,8 +149,7 @@
       "link": "https://github.com/xmendez/wfuzz",
       "name": "Wfuzz",
       "desc": "Web application fuzzer for brute-forcing parameters, forms, and directories",
-      "weight": 6551,
-      "image": "https://avatars.githubusercontent.com/u/789349?v=4"
+      "weight": 6551
     },
     {
       "id": "ffuf/ffuf",
@@ -297,8 +291,7 @@
       "link": "https://github.com/vanhauser-thc/thc-hydra",
       "name": "THC-Hydra",
       "desc": "Parallelized login cracker supporting numerous protocols to attack",
-      "weight": 12151,
-      "image": "https://avatars.githubusercontent.com/u/7396244?v=4"
+      "weight": 12151
     },
     {
       "id": "Pennyw0rth/NetExec",
@@ -319,8 +312,7 @@
       "link": "http://foofus.net/goons/jmk/medusa/medusa.html",
       "name": "Medusa",
       "desc": "Speedy, parallel, and modular login brute-forcer",
-      "weight": 880,
-      "image": "https://avatars.githubusercontent.com/u/12635913?v=4"
+      "weight": 880
     },
     {
       "id": "semgrep/semgrep",
@@ -352,8 +344,7 @@
       "link": "https://brakemanscanner.org/",
       "name": "Brakeman",
       "desc": "Static analysis security vulnerability scanner for Ruby on Rails applications",
-      "weight": 7261,
-      "image": "https://avatars.githubusercontent.com/u/75613?v=4"
+      "weight": 7261
     },
     {
       "id": "github/codeql",

--- a/data/web-dev.json
+++ b/data/web-dev.json
@@ -143,8 +143,7 @@
       "link": "https://esbuild.github.io",
       "name": "esbuild",
       "desc": "An extremely fast bundler for the web",
-      "weight": 40018,
-      "image": "https://avatars.githubusercontent.com/u/406394?v=4"
+      "weight": 40018
     },
     {
       "id": "rollup/rollup",
@@ -198,8 +197,7 @@
       "link": "https://bulma.io",
       "name": "Bulma",
       "desc": "Modern CSS framework based on Flexbox",
-      "weight": 50058,
-      "image": "https://avatars.githubusercontent.com/u/1254808?v=4"
+      "weight": 50058
     },
     {
       "id": "styled-components/styled-components",


### PR DESCRIPTION
## Summary
Follow-up to #10. That fix only covered \`obra/superpowers\`; this sweeps every \`data/*.json\` domain file for the same issue.

Checked every project whose \`image\` pointed at \`avatars.githubusercontent.com\` against the GitHub API:
- **Organization**-owned avatars are legitimate logos — left untouched (the large majority).
- **User**-owned avatars are personal profile photos. 20 such entries (none with a dedicated logo file) had this stale image, across artificial-intelligence, data-science, databases, mobile-dev, security, and web-dev. They now carry no \`image\` and fall back to the generic tile, matching the rule added in #9/#10. \`devops-infra.json\` had none.

\`weight\` is untouched throughout — this is a pure icon-hygiene diff.

## Test plan
- [x] All 6 changed JSON files validated
- [x] \`npm test\` — 126/126 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)