### PR TITLE
feat: add site-wide header/footer linking out to GitHub

### DIFF
--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -442,13 +442,59 @@ body {
   color: var(--color-text-muted);
 }
 
-.back-link {
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
   max-width: 1000px;
-  margin: 12px auto 8px;
-  font-size: 14px;
+  margin: 0 auto;
+  padding: 12px 24px;
 }
 
-.back-link a {
-  color: var(--color-accent);
+.site-header-brand {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--color-text);
   text-decoration: none;
+  letter-spacing: -0.01em;
+}
+
+.site-header-links {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.site-header-github {
+  display: flex;
+  color: var(--color-text-muted);
+}
+
+.site-header-github:hover {
+  color: var(--color-text);
+}
+
+.site-header-stars {
+  display: block;
+  border-radius: 3px;
+}
+
+.site-footer {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px 24px 32px;
+  font-size: 13px;
+}
+
+.site-footer a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
+.site-footer a:hover {
+  color: var(--color-accent);
 }

--- a/app/shared/treemap.js
+++ b/app/shared/treemap.js
@@ -94,7 +94,7 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
   /**
    * The viewport height left for the stage: from the stage's own top
    * (i.e. below whatever precedes it on the page — the mode bar,
-   * breadcrumb, and any page chrome like the "All maps" back-link) down
+   * breadcrumb, and any page chrome like the site header) down
    * to the bottom of the window, minus a small margin. `getBoundingClientRect`
    * is viewport-relative, so this reflects the stage's actual on-page
    * position, not just its container's contents — safe to call before the

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -2,6 +2,8 @@ import { readFileSync } from "node:fs";
 
 const TEMPLATE = readFileSync(new URL("../app/index.html.template", import.meta.url), "utf8");
 
+const REPO_URL = "https://github.com/haggaishachar/awesomemap";
+
 /** Escapes text for safe interpolation into HTML content. */
 function escapeHtml(text) {
   return String(text)
@@ -23,6 +25,32 @@ function escapeScriptJson(json) {
   return json.replace(/</g, "\\u003c");
 }
 
+/** Site-wide nav bar: brand links home, right side links out to the GitHub repo. Omitted from embeds. */
+function renderSiteHeader(basePath) {
+  return `
+    <header class="site-header">
+      <a class="site-header-brand" href="${basePath}/">awesomemap</a>
+      <div class="site-header-links">
+        <a class="site-header-github" href="${REPO_URL}" aria-label="View awesomemap on GitHub">
+          <svg viewBox="0 0 16 16" width="20" height="20" aria-hidden="true">
+            <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+          </svg>
+        </a>
+        <img class="site-header-stars" src="https://img.shields.io/github/stars/haggaishachar/awesomemap?style=social" alt="GitHub stars" width="94" height="20" loading="lazy" />
+      </div>
+    </header>`;
+}
+
+/** Site-wide footer: links back to the repo's license, contributing guide, and issue tracker. Omitted from embeds. */
+function renderSiteFooter() {
+  return `
+    <footer class="site-footer">
+      <a href="${REPO_URL}/blob/master/LICENSE">License</a>
+      <a href="${REPO_URL}/blob/master/CONTRIBUTING.md">Contributing</a>
+      <a href="${REPO_URL}/issues">Report an issue</a>
+    </footer>`;
+}
+
 function renderShell({ title, ogTitle, ogDescription, ogImage, ogUrl, base, body }) {
   return TEMPLATE.replace(/{{TITLE}}/g, () => escapeHtml(title))
     .replace(/{{OG_TITLE}}/g, () => escapeHtml(ogTitle))
@@ -40,7 +68,8 @@ function renderShell({ title, ogTitle, ogDescription, ogImage, ogUrl, base, body
  * direct URL into the project's source repo, ready to use as-is.
  */
 export function renderDomainPage(domain, tree, { embed = false, defaultOgImage, siteUrl = "", basePath = "" }) {
-  const backLink = embed ? "" : `<p class="back-link"><a href="${basePath}/">&larr; All maps</a></p>`;
+  const header = embed ? "" : renderSiteHeader(basePath);
+  const footer = embed ? "" : renderSiteFooter();
   const ogUrl = `${siteUrl}${basePath}/${domain.slug}/`;
   // The domain's own `history.json` (copied from `data/history/<slug>.json`
   // by generate.mjs, when it exists) — fetched lazily by the detail panel
@@ -49,7 +78,7 @@ export function renderDomainPage(domain, tree, { embed = false, defaultOgImage, 
   // chart) rather than needing generate.mjs's fs state here.
   const historyUrl = `${basePath}/${domain.slug}/history.json`;
   const body = `
-    ${backLink}
+    ${header}
     <div id="app"></div>
     <script type="application/json" id="map-data">${escapeScriptJson(JSON.stringify(tree))}</script>
     <script type="module">
@@ -64,6 +93,7 @@ export function renderDomainPage(domain, tree, { embed = false, defaultOgImage, 
         () => panel.close()
       );
     </script>
+    ${footer}
   `;
   return renderShell({
     title: domain.name,
@@ -88,6 +118,7 @@ export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", baseP
     )
     .join("");
   const body = `
+    ${renderSiteHeader(basePath)}
     <header class="hero">
       <div class="hero-motif" aria-hidden="true">
         <span class="hero-rect hero-rect-1"></span>
@@ -104,6 +135,7 @@ export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", baseP
       <h2 class="map-index-heading">Explore the maps</h2>
       <div class="map-grid">${cards}</div>
     </div>
+    ${renderSiteFooter()}
   `;
   return renderShell({
     title: "awesomemap",

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -42,13 +42,13 @@ test("BASE_PATH is prefixed onto every emitted path, and defaults to root-relati
   const rootHtml = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png", basePath: "" });
   assert.match(rootHtml, /href="\/shared\/treemap.css"/);
   assert.match(rootHtml, /"d3-hierarchy": "\/vendor\/d3-hierarchy\/index.js"/);
-  assert.match(rootHtml, /href="\/">&larr; All maps<\/a>/);
+  assert.match(rootHtml, /class="site-header-brand" href="\/"/);
   assert.match(rootHtml, /import \{ mountTreemap \} from "\/shared\/treemap.js"/);
 
   const prefixedHtml = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png", basePath: "/techmap" });
   assert.match(prefixedHtml, /href="\/techmap\/shared\/treemap.css"/);
   assert.match(prefixedHtml, /"d3-hierarchy": "\/techmap\/vendor\/d3-hierarchy\/index.js"/);
-  assert.match(prefixedHtml, /href="\/techmap\/">&larr; All maps<\/a>/);
+  assert.match(prefixedHtml, /class="site-header-brand" href="\/techmap\/"/);
   assert.match(prefixedHtml, /import \{ mountTreemap \} from "\/techmap\/shared\/treemap.js"/);
 });
 
@@ -75,16 +75,32 @@ test("og:image and og:url are absolute when SITE_URL is set (origin only, combin
   assert.match(html, /property="og:url" content="https:\/\/haggaishachar\.github\.io\/techmap\/data-science\/"/);
 });
 
-test("the 'All maps' back-link is placed before #app, not after — reachable without scrolling past the map", () => {
+test("the site header is placed before #app, not after — reachable without scrolling past the map", () => {
   const domain = { slug: "data-science", name: "Data Science", description: "desc" };
   const html = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png" });
-  assert.ok(html.indexOf('class="back-link"') < html.indexOf('id="app"'));
+  assert.ok(html.indexOf('class="site-header"') < html.indexOf('id="app"'));
 });
 
-test("the embed variant has no back-link and starts straight at #app", () => {
+test("the embed variant has no site header or footer and starts straight at #app", () => {
   const domain = { slug: "data-science", name: "Data Science", description: "desc" };
   const html = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png", embed: true });
-  assert.doesNotMatch(html, /back-link/);
+  assert.doesNotMatch(html, /site-header/);
+  assert.doesNotMatch(html, /site-footer/);
+});
+
+test("the domain page header links to the GitHub repo", () => {
+  const domain = { slug: "data-science", name: "Data Science", description: "desc" };
+  const html = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png" });
+  assert.match(html, /class="site-header-github" href="https:\/\/github\.com\/haggaishachar\/awesomemap"/);
+});
+
+test("the domain page footer links to license, contributing, and issues", () => {
+  const domain = { slug: "data-science", name: "Data Science", description: "desc" };
+  const html = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png" });
+  assert.match(html, /class="site-footer"/);
+  assert.match(html, /href="https:\/\/github\.com\/haggaishachar\/awesomemap\/blob\/master\/LICENSE"/);
+  assert.match(html, /href="https:\/\/github\.com\/haggaishachar\/awesomemap\/blob\/master\/CONTRIBUTING\.md"/);
+  assert.match(html, /href="https:\/\/github\.com\/haggaishachar\/awesomemap\/issues"/);
 });
 
 test("landing page card links escape the slug and use a trailing slash", () => {
@@ -113,4 +129,32 @@ test("landing page renders a hero with title and tagline above the map grid", ()
   assert.match(html, /class="hero-tagline"/);
   // Hero must come before the map grid in document order.
   assert.ok(html.indexOf('class="hero"') < html.indexOf('class="map-grid"'));
+});
+
+test("landing page renders a site header, with GitHub link, above the hero", () => {
+  const html = renderLandingPage(
+    [{ slug: "data-science", name: "Data Science", description: "desc" }],
+    { defaultOgImage: "/og-default.png", basePath: "" }
+  );
+  assert.match(html, /class="site-header-github" href="https:\/\/github\.com\/haggaishachar\/awesomemap"/);
+  assert.ok(html.indexOf('class="site-header"') < html.indexOf('class="hero"'));
+});
+
+test("landing page site header brand link respects BASE_PATH", () => {
+  const html = renderLandingPage(
+    [{ slug: "data-science", name: "Data Science", description: "desc" }],
+    { defaultOgImage: "/og-default.png", basePath: "/techmap" }
+  );
+  assert.match(html, /class="site-header-brand" href="\/techmap\/"/);
+});
+
+test("landing page renders a site footer, with license/contributing/issues links, below the map grid", () => {
+  const html = renderLandingPage(
+    [{ slug: "data-science", name: "Data Science", description: "desc" }],
+    { defaultOgImage: "/og-default.png", basePath: "" }
+  );
+  assert.match(html, /href="https:\/\/github\.com\/haggaishachar\/awesomemap\/blob\/master\/LICENSE"/);
+  assert.match(html, /href="https:\/\/github\.com\/haggaishachar\/awesomemap\/blob\/master\/CONTRIBUTING\.md"/);
+  assert.match(html, /href="https:\/\/github\.com\/haggaishachar\/awesomemap\/issues"/);
+  assert.ok(html.indexOf('class="map-grid"') < html.indexOf('class="site-footer"'));
 });


### PR DESCRIPTION
## Summary
- Adds a persistent top nav bar (brand + GitHub icon + live star badge) and a footer (License · Contributing · Report an issue) across the landing page and all domain pages.
- Replaces the old bare "← All maps" back-link with the header's brand link (same job, more standard chrome).
- Embed pages (iframe use) keep no chrome, unchanged.

## Why
Give the site the look of a typical open-source project's site, with the GitHub repo always one click away.

## Testing
- `npm test` — 131/131 pass, including new/updated coverage in `test/render-page.test.js`.
- `node scripts/generate.mjs` + manual visual check (headless Chrome screenshots) of the landing page and a domain page, in both light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)