### PR TITLE
fix: smooth rising score to stop tiny-project noise outranking real growth

### DIFF
--- a/scripts/velocity.mjs
+++ b/scripts/velocity.mjs
@@ -9,6 +9,17 @@ const SCORE_FLOOR = 0.01;
 /** Rising windows this feature supports, in days. */
 export const RISING_WINDOWS_DAYS = [7, 30, 90];
 
+// Pseudo-count added to currentStars before taking sqrt() in the score
+// formula below. Without it, a tiny/young project's noisy swing (e.g. 2 ->
+// 6 stars) can outscore a large project's genuinely bigger gain (e.g.
+// 100,000 -> 100,200 stars), because sqrt(currentStars) shrinks just as
+// fast as the numerator when currentStars is small. Calibrated against
+// this repo's tracked projects (data/*.json star counts range from ~500 to
+// ~386k, with the 10th percentile around 6,200): large enough to damp
+// swings at the low end of that range, small enough to stay negligible
+// past the low thousands.
+export const SCORE_SMOOTHING_CONSTANT = 2000;
+
 /**
  * Computes a growth-velocity score for one project from its raw star-count
  * history. `history` is an array of `{ date: "YYYY-MM-DD", stars }`
@@ -20,9 +31,11 @@ export const RISING_WINDOWS_DAYS = [7, 30, 90];
  * false when even the oldest snapshot is younger than the window, since
  * there's no data point far back enough to measure the full window from.
  *
- * `score = starDelta / sqrt(max(currentStars, 1))`, floored at
- * `SCORE_FLOOR` so it's always a valid positive treemap weight, even for
- * a shrinking project.
+ * `score = starDelta / sqrt(currentStars + SCORE_SMOOTHING_CONSTANT)`,
+ * floored at `SCORE_FLOOR` so it's always a valid positive treemap weight,
+ * even for a shrinking project. The smoothing constant keeps a tiny
+ * project's noisy swing from outscoring a large project's genuinely
+ * bigger gain (see `SCORE_SMOOTHING_CONSTANT`'s doc comment).
  */
 export function computeVelocity(history, windowDays, { now = new Date() } = {}) {
   const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
@@ -47,7 +60,7 @@ export function computeVelocity(history, windowDays, { now = new Date() } = {}) 
 
   const starDelta = currentStars - baseline.stars;
   const percentDelta = baseline.stars > 0 ? (starDelta / baseline.stars) * 100 : 0;
-  const rawScore = starDelta / Math.sqrt(Math.max(currentStars, 1));
+  const rawScore = starDelta / Math.sqrt(currentStars + SCORE_SMOOTHING_CONSTANT);
 
   return { score: Math.max(rawScore, SCORE_FLOOR), hasEnoughHistory: true, starDelta, percentDelta, oldestDate };
 }

--- a/test/velocity.test.js
+++ b/test/velocity.test.js
@@ -1,6 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { computeVelocity, computeProjectSizing, findInvalidSizes, RISING_WINDOWS_DAYS } from "../scripts/velocity.mjs";
+import {
+  computeVelocity,
+  computeProjectSizing,
+  findInvalidSizes,
+  RISING_WINDOWS_DAYS,
+  SCORE_SMOOTHING_CONSTANT,
+} from "../scripts/velocity.mjs";
 
 const NOW = "2026-08-08T00:00:00.000Z";
 
@@ -67,6 +73,43 @@ test("computeVelocity reports oldestDate as the earliest snapshot's date, even w
 
   const sufficient = computeVelocity(history, 7, { now: NOW });
   assert.equal(sufficient.oldestDate, "2026-08-01");
+});
+
+test("computeVelocity's score divides by sqrt(currentStars + SCORE_SMOOTHING_CONSTANT), not sqrt(currentStars) alone", () => {
+  const history = [
+    { date: "2026-07-09", stars: 500 },
+    { date: "2026-08-08", stars: 600 },
+  ];
+  const result = computeVelocity(history, 30, { now: NOW });
+  const expectedScore = 100 / Math.sqrt(600 + SCORE_SMOOTHING_CONSTANT);
+  assert.equal(result.score, expectedScore);
+});
+
+test("a project with genuinely large absolute growth outscores a tiny project's noisy swing", () => {
+  // Without smoothing, 2 -> 6 stars (a 3x move driven by pure noise) can
+  // outscore 100,000 -> 100,200 stars (a real, substantial gain), because
+  // sqrt(currentStars) shrinks just as fast as the numerator for small
+  // counts. The smoothing constant should flip this ordering back.
+  const noisy = computeVelocity(
+    [
+      { date: "2026-07-09", stars: 2 },
+      { date: "2026-08-08", stars: 6 },
+    ],
+    30,
+    { now: NOW },
+  );
+  const realRiser = computeVelocity(
+    [
+      { date: "2026-07-09", stars: 100000 },
+      { date: "2026-08-08", stars: 100200 },
+    ],
+    30,
+    { now: NOW },
+  );
+  assert.ok(
+    realRiser.score > noisy.score,
+    `expected real riser (${realRiser.score}) to outscore noise (${noisy.score})`,
+  );
 });
 
 test("computeVelocity treats a zero-star baseline as 0% growth rather than dividing by zero", () => {


### PR DESCRIPTION
## Summary
`computeVelocity`'s rising score divided `starDelta` by `sqrt(currentStars)` alone. That shrinks just as fast as the numerator for small counts, so a project noise-jumping 2 → 6 stars could outscore one gaining 200 stars off a 100,000-star base.

## Fix
Add `SCORE_SMOOTHING_CONSTANT` (2000) to the denominator before the sqrt:

```
score = starDelta / sqrt(currentStars + SCORE_SMOOTHING_CONSTANT)
```

Calibrated from this repo's tracked star-count distribution (`data/*.json`: ~500 to ~386k stars, 10th percentile ~6,200) — large enough to damp noise at the low end, negligible past the low thousands.

## Testing
Added a test asserting the exact new formula, and an acceptance test reproducing the reported failure mode (2→6 star noise vs. 100,000→100,200 real gain) — confirmed it failed against the old formula before the fix. Full suite: 133/133 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)