### PR TITLE
Add missing projects to 4 maps, create Automation and IoT/Smart Home domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ interactive rankings across any window, use Rising mode in the maps below.
 | Map | Description | Projects |
 | --- | --- | --- |
 | [Data Science](https://awesomemap.dev/data-science/) | Machine learning, deep learning, NLP, computer vision, and more. | 51 |
-| [Security](https://awesomemap.dev/security/) | Scanning, exploitation, SIEM, secrets management, forensics, and more. | 51 |
-| [Web Development](https://awesomemap.dev/web-dev/) | Frontend frameworks, build tools, styling, backend frameworks, and more. | 50 |
+| [Security](https://awesomemap.dev/security/) | Scanning, exploitation, SIEM, secrets management, forensics, and more. | 55 |
+| [Web Development](https://awesomemap.dev/web-dev/) | Frontend frameworks, build tools, styling, backend frameworks, and more. | 55 |
 | [Mobile Development](https://awesomemap.dev/mobile-dev/) | Cross-platform frameworks, native tooling, testing, state management, and more. | 46 |
-| [DevOps & Infrastructure](https://awesomemap.dev/devops-infra/) | Containers, orchestration, CI/CD, infrastructure as code, observability, and more. | 50 |
+| [DevOps & Infrastructure](https://awesomemap.dev/devops-infra/) | Containers, orchestration, CI/CD, infrastructure as code, observability, and more. | 54 |
 | [Artificial Intelligence](https://awesomemap.dev/artificial-intelligence/) | LLM frameworks, AI agents, RAG, vector databases, coding assistants, and more. | 53 |
-| [Databases & Data Infrastructure](https://awesomemap.dev/databases/) | Relational, NoSQL, caching, search, streaming, analytics, and more. | 49 |
+| [Databases & Data Infrastructure](https://awesomemap.dev/databases/) | Relational, NoSQL, caching, search, streaming, analytics, and more. | 50 |
+| [Automation & No-Code](https://awesomemap.dev/automation/) | Workflow automation, RPA, no-code app builders, and business process tooling. | 48 |
+| [IoT & Smart Home](https://awesomemap.dev/smart-home/) | Home automation platforms, embedded firmware, robotics, and device protocols. | 41 |
 
 More domains are on the way.
 

--- a/data/automation.json
+++ b/data/automation.json
@@ -1,0 +1,532 @@
+{
+  "slug": "automation",
+  "name": "Best Automation & No-Code Open Source Projects",
+  "description": "Workflow automation, RPA, no-code app builders, and business process tooling.",
+  "projects": [
+    {
+      "id": "n8n-io/n8n",
+      "path": [
+        "Workflow Automation"
+      ],
+      "link": "https://n8n.io",
+      "name": "n8n",
+      "desc": "Fair-code workflow automation platform with native AI capabilities",
+      "weight": 201299,
+      "image": "https://avatars.githubusercontent.com/u/45487711?v=4"
+    },
+    {
+      "id": "node-red/node-red",
+      "path": [
+        "Workflow Automation"
+      ],
+      "link": "http://nodered.org",
+      "name": "Node-RED",
+      "desc": "Low-code, flow-based programming tool for wiring together APIs and devices",
+      "weight": 23553,
+      "image": "https://avatars.githubusercontent.com/u/5375661?v=4"
+    },
+    {
+      "id": "activepieces/activepieces",
+      "path": [
+        "Workflow Automation"
+      ],
+      "link": "https://www.activepieces.com",
+      "name": "Activepieces",
+      "desc": "Open-source AI-powered workflow automation platform",
+      "weight": 23923,
+      "image": "https://avatars.githubusercontent.com/u/99494700?v=4"
+    },
+    {
+      "id": "automatisch/automatisch",
+      "path": [
+        "Workflow Automation"
+      ],
+      "link": "https://automatisch.io",
+      "name": "Automatisch",
+      "desc": "Open-source alternative to Zapier for workflow automation",
+      "weight": 13938,
+      "image": "https://avatars.githubusercontent.com/u/91699546?v=4"
+    },
+    {
+      "id": "windmill-labs/windmill",
+      "path": [
+        "Workflow Automation"
+      ],
+      "link": "https://windmill.dev",
+      "name": "Windmill",
+      "desc": "Developer platform for turning scripts into workflows, webhooks, and UIs",
+      "weight": 17589,
+      "image": "https://avatars.githubusercontent.com/u/98025271?v=4"
+    },
+    {
+      "id": "huginn/huginn",
+      "path": [
+        "Workflow Automation"
+      ],
+      "link": "https://github.com/huginn/huginn",
+      "name": "Huginn",
+      "desc": "Build agents that monitor events and act on your behalf",
+      "weight": 49825,
+      "image": "https://avatars.githubusercontent.com/u/23225142?v=4"
+    },
+    {
+      "id": "apache/airflow",
+      "path": [
+        "Workflow Automation"
+      ],
+      "link": "https://airflow.apache.org/",
+      "name": "Apache Airflow",
+      "desc": "Platform to programmatically author, schedule, and monitor workflows",
+      "weight": 46547,
+      "image": "https://avatars.githubusercontent.com/u/47359?v=4"
+    },
+    {
+      "id": "temporalio/temporal",
+      "path": [
+        "Job Orchestration & Scheduling"
+      ],
+      "link": "https://docs.temporal.io",
+      "name": "Temporal",
+      "desc": "Durable execution platform for orchestrating reliable distributed workflows",
+      "weight": 22418,
+      "image": "https://avatars.githubusercontent.com/u/56493103?v=4"
+    },
+    {
+      "id": "PrefectHQ/prefect",
+      "path": [
+        "Job Orchestration & Scheduling"
+      ],
+      "link": "https://prefect.io",
+      "name": "Prefect",
+      "desc": "Workflow orchestration framework for building resilient data pipelines",
+      "weight": 23648,
+      "image": "https://avatars.githubusercontent.com/u/39270919?v=4"
+    },
+    {
+      "id": "dagster-io/dagster",
+      "path": [
+        "Job Orchestration & Scheduling"
+      ],
+      "link": "https://dagster.io",
+      "name": "Dagster",
+      "desc": "Orchestration platform for the development and observation of data assets",
+      "weight": 16028,
+      "image": "https://avatars.githubusercontent.com/u/40032576?v=4"
+    },
+    {
+      "id": "Netflix/conductor",
+      "path": [
+        "Job Orchestration & Scheduling"
+      ],
+      "link": "https://github.com/Netflix/conductor",
+      "name": "Conductor",
+      "desc": "Microservices orchestration engine",
+      "weight": 12752,
+      "image": "https://avatars.githubusercontent.com/u/913567?v=4"
+    },
+    {
+      "id": "cadence-workflow/cadence",
+      "path": [
+        "Job Orchestration & Scheduling"
+      ],
+      "link": "https://cadenceworkflow.io",
+      "name": "Cadence",
+      "desc": "Distributed, scalable orchestration engine for long-running business logic",
+      "weight": 9407,
+      "image": "https://avatars.githubusercontent.com/u/187651631?v=4"
+    },
+    {
+      "id": "kestra-io/kestra",
+      "path": [
+        "Job Orchestration & Scheduling"
+      ],
+      "link": "https://go.kestra.io/home",
+      "name": "Kestra",
+      "desc": "Event-driven orchestration and scheduling platform",
+      "weight": 27859,
+      "image": "https://avatars.githubusercontent.com/u/59033362?v=4"
+    },
+    {
+      "id": "rundeck/rundeck",
+      "path": [
+        "Job Orchestration & Scheduling"
+      ],
+      "link": "http://rundeck.org",
+      "name": "Rundeck",
+      "desc": "Self-service job scheduling and runbook automation",
+      "weight": 6275,
+      "image": "https://avatars.githubusercontent.com/u/2205640?v=4"
+    },
+    {
+      "id": "healthchecks/healthchecks",
+      "path": [
+        "Job Orchestration & Scheduling"
+      ],
+      "link": "https://healthchecks.io",
+      "name": "Healthchecks",
+      "desc": "Cron job and background task monitoring service",
+      "weight": 10264,
+      "image": "https://avatars.githubusercontent.com/u/13053880?v=4"
+    },
+    {
+      "id": "open-rpa/openrpa",
+      "path": [
+        "RPA & Browser Automation"
+      ],
+      "link": "https://app.openiap.io",
+      "name": "OpenRPA",
+      "desc": "Open-source robotic process automation platform",
+      "weight": 3044,
+      "image": "https://avatars.githubusercontent.com/u/49598537?v=4"
+    },
+    {
+      "id": "aisingapore/TagUI",
+      "path": [
+        "RPA & Browser Automation"
+      ],
+      "link": "https://github.com/aisingapore/TagUI",
+      "name": "TagUI",
+      "desc": "Free command-line RPA tool for automating web, desktop, and CLI tasks",
+      "weight": 6323,
+      "image": "https://avatars.githubusercontent.com/u/110224767?v=4"
+    },
+    {
+      "id": "robocorp/rpaframework",
+      "path": [
+        "RPA & Browser Automation"
+      ],
+      "link": "https://www.rpaframework.org/",
+      "name": "RPA Framework",
+      "desc": "Open-source libraries for robotic process automation with Python",
+      "weight": 1547,
+      "image": "https://avatars.githubusercontent.com/u/54288445?v=4"
+    },
+    {
+      "id": "SeleniumHQ/selenium",
+      "path": [
+        "RPA & Browser Automation"
+      ],
+      "link": "https://selenium.dev",
+      "name": "Selenium",
+      "desc": "Browser automation framework and ecosystem",
+      "weight": 34380,
+      "image": "https://avatars.githubusercontent.com/u/983927?v=4"
+    },
+    {
+      "id": "robotframework/robotframework",
+      "path": [
+        "RPA & Browser Automation"
+      ],
+      "link": "http://robotframework.org",
+      "name": "Robot Framework",
+      "desc": "Generic automation framework for acceptance testing and RPA",
+      "weight": 11827,
+      "image": "https://avatars.githubusercontent.com/u/574284?v=4"
+    },
+    {
+      "id": "scrapy/scrapy",
+      "path": [
+        "Web Scraping & Data Extraction"
+      ],
+      "link": "https://scrapy.org",
+      "name": "Scrapy",
+      "desc": "Fast, high-level web crawling and scraping framework for Python",
+      "weight": 63974,
+      "image": "https://avatars.githubusercontent.com/u/733635?v=4"
+    },
+    {
+      "id": "apify/crawlee",
+      "path": [
+        "Web Scraping & Data Extraction"
+      ],
+      "link": "https://crawlee.dev",
+      "name": "Crawlee",
+      "desc": "Web scraping and browser automation library for Node.js",
+      "weight": 25445,
+      "image": "https://avatars.githubusercontent.com/u/24586296?v=4"
+    },
+    {
+      "id": "unclecode/crawl4ai",
+      "path": [
+        "Web Scraping & Data Extraction"
+      ],
+      "link": "https://crawl4ai.com",
+      "name": "Crawl4AI",
+      "desc": "Open-source LLM-friendly web crawler and scraper",
+      "weight": 78756
+    },
+    {
+      "id": "puppeteer/puppeteer",
+      "path": [
+        "Web Scraping & Data Extraction"
+      ],
+      "link": "https://pptr.dev",
+      "name": "Puppeteer",
+      "desc": "JavaScript API for automating Chrome and Firefox",
+      "weight": 95472,
+      "image": "https://avatars.githubusercontent.com/u/6906516?v=4"
+    },
+    {
+      "id": "Unstructured-IO/unstructured",
+      "path": [
+        "Web Scraping & Data Extraction"
+      ],
+      "link": "https://www.unstructured.io/",
+      "name": "Unstructured",
+      "desc": "Open-source ETL for turning complex documents into clean, structured data",
+      "weight": 15325,
+      "image": "https://avatars.githubusercontent.com/u/108372208?v=4"
+    },
+    {
+      "id": "microsoft/markitdown",
+      "path": [
+        "Web Scraping & Data Extraction"
+      ],
+      "link": "https://github.com/microsoft/markitdown",
+      "name": "MarkItDown",
+      "desc": "Tool for converting files and office documents to Markdown",
+      "weight": 174833,
+      "image": "https://avatars.githubusercontent.com/u/6154722?v=4"
+    },
+    {
+      "id": "appsmithorg/appsmith",
+      "path": [
+        "Low-Code & No-Code Builders"
+      ],
+      "link": "https://www.appsmith.com",
+      "name": "Appsmith",
+      "desc": "Platform for building admin panels, internal tools, and dashboards",
+      "weight": 40709,
+      "image": "https://avatars.githubusercontent.com/u/67620218?v=4"
+    },
+    {
+      "id": "ToolJet/ToolJet",
+      "path": [
+        "Low-Code & No-Code Builders"
+      ],
+      "link": "https://tooljet.com",
+      "name": "ToolJet",
+      "desc": "Low-code platform for building internal tools and business applications",
+      "weight": 40554,
+      "image": "https://avatars.githubusercontent.com/u/82193554?v=4"
+    },
+    {
+      "id": "Budibase/budibase",
+      "path": [
+        "Low-Code & No-Code Builders"
+      ],
+      "link": "https://budibase.com",
+      "name": "Budibase",
+      "desc": "Low-code platform for building internal apps and automations",
+      "weight": 28224,
+      "image": "https://avatars.githubusercontent.com/u/45009727?v=4"
+    },
+    {
+      "id": "nocodb/nocodb",
+      "path": [
+        "Low-Code & No-Code Builders"
+      ],
+      "link": "https://nocodb.com",
+      "name": "NocoDB",
+      "desc": "Open-source, self-hostable Airtable alternative",
+      "weight": 64597,
+      "image": "https://avatars.githubusercontent.com/u/50206778?v=4"
+    },
+    {
+      "id": "baserow/baserow",
+      "path": [
+        "Low-Code & No-Code Builders"
+      ],
+      "link": "https://baserow.io",
+      "name": "Baserow",
+      "desc": "Open-source no-code database and app builder",
+      "weight": 5640,
+      "image": "https://avatars.githubusercontent.com/u/68540644?v=4"
+    },
+    {
+      "id": "illacloud/illa-builder",
+      "path": [
+        "Low-Code & No-Code Builders"
+      ],
+      "link": "https://github.com/illacloud/illa-builder",
+      "name": "ILLA Builder",
+      "desc": "Low-code platform for building internal business apps",
+      "weight": 12311,
+      "image": "https://avatars.githubusercontent.com/u/93245159?v=4"
+    },
+    {
+      "id": "nocobase/nocobase",
+      "path": [
+        "Low-Code & No-Code Builders"
+      ],
+      "link": "https://www.nocobase.com",
+      "name": "NocoBase",
+      "desc": "Open-source no-code platform for building business systems",
+      "weight": 23709,
+      "image": "https://avatars.githubusercontent.com/u/66196787?v=4"
+    },
+    {
+      "id": "strapi/strapi",
+      "path": [
+        "Low-Code & No-Code Builders"
+      ],
+      "link": "https://strapi.io",
+      "name": "Strapi",
+      "desc": "Leading open-source headless CMS",
+      "weight": 72976,
+      "image": "https://avatars.githubusercontent.com/u/19872173?v=4"
+    },
+    {
+      "id": "directus/directus",
+      "path": [
+        "Low-Code & No-Code Builders"
+      ],
+      "link": "https://directus.com",
+      "name": "Directus",
+      "desc": "Flexible headless CMS that turns any database into an API",
+      "weight": 37485,
+      "image": "https://avatars.githubusercontent.com/u/15967950?v=4"
+    },
+    {
+      "id": "odoo/odoo",
+      "path": [
+        "Business Process, ERP & Finance"
+      ],
+      "link": "https://www.odoo.com",
+      "name": "Odoo",
+      "desc": "Suite of open-source business applications for running a company",
+      "weight": 53816,
+      "image": "https://avatars.githubusercontent.com/u/6368483?v=4"
+    },
+    {
+      "id": "frappe/erpnext",
+      "path": [
+        "Business Process, ERP & Finance"
+      ],
+      "link": "https://frappe.io/erpnext",
+      "name": "ERPNext",
+      "desc": "Free and open-source enterprise resource planning system",
+      "weight": 38301,
+      "image": "https://avatars.githubusercontent.com/u/836974?v=4"
+    },
+    {
+      "id": "camunda/camunda",
+      "path": [
+        "Business Process, ERP & Finance"
+      ],
+      "link": "https://camunda.com/platform/",
+      "name": "Camunda",
+      "desc": "Process orchestration and workflow automation framework",
+      "weight": 4254,
+      "image": "https://avatars.githubusercontent.com/u/2443838?v=4"
+    },
+    {
+      "id": "twentyhq/twenty",
+      "path": [
+        "Business Process, ERP & Finance"
+      ],
+      "link": "https://twenty.com",
+      "name": "Twenty",
+      "desc": "Open-source CRM alternative to Salesforce",
+      "weight": 55175,
+      "image": "https://avatars.githubusercontent.com/u/119600397?v=4"
+    },
+    {
+      "id": "documenso/documenso",
+      "path": [
+        "Business Process, ERP & Finance"
+      ],
+      "link": "https://documenso.com",
+      "name": "Documenso",
+      "desc": "Open-source alternative to DocuSign for document signing",
+      "weight": 14627,
+      "image": "https://avatars.githubusercontent.com/u/127681099?v=4"
+    },
+    {
+      "id": "formbricks/formbricks",
+      "path": [
+        "Business Process, ERP & Finance"
+      ],
+      "link": "https://formbricks.com",
+      "name": "Formbricks",
+      "desc": "Open-source survey and experience management platform",
+      "weight": 12795,
+      "image": "https://avatars.githubusercontent.com/u/105877416?v=4"
+    },
+    {
+      "id": "invoiceninja/invoiceninja",
+      "path": [
+        "Business Process, ERP & Finance"
+      ],
+      "link": "https://invoiceninja.com",
+      "name": "Invoice Ninja",
+      "desc": "Invoicing, quoting, and time-tracking application",
+      "weight": 10011,
+      "image": "https://avatars.githubusercontent.com/u/15712270?v=4"
+    },
+    {
+      "id": "airbytehq/airbyte",
+      "path": [
+        "Data & Notification Integration"
+      ],
+      "link": "https://airbyte.com",
+      "name": "Airbyte",
+      "desc": "Open-source data movement platform for ELT pipelines",
+      "weight": 21924,
+      "image": "https://avatars.githubusercontent.com/u/59758427?v=4"
+    },
+    {
+      "id": "dlt-hub/dlt",
+      "path": [
+        "Data & Notification Integration"
+      ],
+      "link": "https://dlthub.com/docs",
+      "name": "dlt",
+      "desc": "Python library for loading data into warehouses and lakes",
+      "weight": 5758,
+      "image": "https://avatars.githubusercontent.com/u/89419010?v=4"
+    },
+    {
+      "id": "novuhq/novu",
+      "path": [
+        "Data & Notification Integration"
+      ],
+      "link": "https://go.novu.co/github",
+      "name": "Novu",
+      "desc": "Open-source notification infrastructure for multi-channel messaging",
+      "weight": 39619,
+      "image": "https://avatars.githubusercontent.com/u/77433905?v=4"
+    },
+    {
+      "id": "binwiederhier/ntfy",
+      "path": [
+        "Data & Notification Integration"
+      ],
+      "link": "https://ntfy.sh",
+      "name": "ntfy",
+      "desc": "Simple pub-sub push notification service",
+      "weight": 33633
+    },
+    {
+      "id": "mautic/mautic",
+      "path": [
+        "Marketing & Email Automation"
+      ],
+      "link": "https://www.mautic.org",
+      "name": "Mautic",
+      "desc": "Open-source marketing automation software",
+      "weight": 10372,
+      "image": "https://avatars.githubusercontent.com/u/5257677?v=4"
+    },
+    {
+      "id": "knadh/listmonk",
+      "path": [
+        "Marketing & Email Automation"
+      ],
+      "link": "https://listmonk.app",
+      "name": "listmonk",
+      "desc": "Self-hosted newsletter and mailing list manager",
+      "weight": 23011
+    }
+  ]
+}

--- a/data/databases.json
+++ b/data/databases.json
@@ -11,7 +11,7 @@
       "link": "https://www.postgresql.org/",
       "name": "PostgreSQL",
       "desc": "Mirror of the PostgreSQL git repositories",
-      "weight": 21783,
+      "weight": 21849,
       "image": "https://avatars.githubusercontent.com/u/177543?v=4"
     },
     {
@@ -22,7 +22,7 @@
       "link": "https://www.mysql.com/",
       "name": "MySQL",
       "desc": "MySQL server, the world's most popular open source database",
-      "weight": 12380,
+      "weight": 12387,
       "image": "https://avatars.githubusercontent.com/u/2452804?v=4"
     },
     {
@@ -33,7 +33,7 @@
       "link": "https://www.sqlite.org/",
       "name": "SQLite",
       "desc": "Official Git mirror of the SQLite source tree",
-      "weight": 10254
+      "weight": 10304
     },
     {
       "id": "cockroachdb/cockroach",
@@ -43,7 +43,7 @@
       "link": "https://www.cockroachlabs.com/",
       "name": "CockroachDB",
       "desc": "Distributed, scalable, cloud-native SQL database",
-      "weight": 32385,
+      "weight": 32404,
       "image": "https://avatars.githubusercontent.com/u/6748139?v=4"
     },
     {
@@ -54,7 +54,7 @@
       "link": "https://mariadb.org/",
       "name": "MariaDB",
       "desc": "A community-developed fork of MySQL",
-      "weight": 8090,
+      "weight": 8113,
       "image": "https://avatars.githubusercontent.com/u/4739304?v=4"
     },
     {
@@ -65,7 +65,7 @@
       "link": "https://www.mongodb.com/",
       "name": "MongoDB",
       "desc": "The MongoDB database server",
-      "weight": 28491,
+      "weight": 28503,
       "image": "https://avatars.githubusercontent.com/u/45120?v=4"
     },
     {
@@ -76,7 +76,7 @@
       "link": "https://cassandra.apache.org/",
       "name": "Apache Cassandra",
       "desc": "A distributed NoSQL database management system",
-      "weight": 10069,
+      "weight": 10076,
       "image": "https://avatars.githubusercontent.com/u/47359?v=4"
     },
     {
@@ -87,7 +87,7 @@
       "link": "https://couchdb.apache.org/",
       "name": "Apache CouchDB",
       "desc": "Seamless multi-master syncing document database",
-      "weight": 6936,
+      "weight": 6939,
       "image": "https://avatars.githubusercontent.com/u/47359?v=4"
     },
     {
@@ -98,7 +98,7 @@
       "link": "https://www.scylladb.com/",
       "name": "ScyllaDB",
       "desc": "NoSQL data store using the seastar framework, compatible with Cassandra",
-      "weight": 15705,
+      "weight": 15719,
       "image": "https://avatars.githubusercontent.com/u/14364730?v=4"
     },
     {
@@ -109,7 +109,7 @@
       "link": "https://redis.io/",
       "name": "Redis",
       "desc": "In-memory data structure store used as a database, cache, and broker",
-      "weight": 76003,
+      "weight": 76055,
       "image": "https://avatars.githubusercontent.com/u/1529926?v=4"
     },
     {
@@ -120,7 +120,7 @@
       "link": "https://valkey.io/",
       "name": "Valkey",
       "desc": "A flexible, high-performance key-value datastore, forked from Redis",
-      "weight": 26878,
+      "weight": 26930,
       "image": "https://avatars.githubusercontent.com/u/164458127?v=4"
     },
     {
@@ -131,7 +131,7 @@
       "link": "https://memcached.org/",
       "name": "Memcached",
       "desc": "A distributed memory object caching system",
-      "weight": 14250,
+      "weight": 14254,
       "image": "https://avatars.githubusercontent.com/u/41836?v=4"
     },
     {
@@ -142,7 +142,7 @@
       "link": "https://etcd.io/",
       "name": "etcd",
       "desc": "Distributed reliable key-value store for the most critical data",
-      "weight": 52119,
+      "weight": 52135,
       "image": "https://avatars.githubusercontent.com/u/41972792?v=4"
     },
     {
@@ -153,7 +153,7 @@
       "link": "https://www.elastic.co/elasticsearch",
       "name": "Elasticsearch",
       "desc": "Distributed, RESTful search and analytics engine",
-      "weight": 77849,
+      "weight": 77844,
       "image": "https://avatars.githubusercontent.com/u/6764390?v=4"
     },
     {
@@ -164,7 +164,7 @@
       "link": "https://opensearch.org/",
       "name": "OpenSearch",
       "desc": "Open source distributed and RESTful search engine",
-      "weight": 13516,
+      "weight": 13550,
       "image": "https://avatars.githubusercontent.com/u/80134844?v=4"
     },
     {
@@ -175,7 +175,7 @@
       "link": "https://www.meilisearch.com/",
       "name": "Meilisearch",
       "desc": "A lightning-fast search engine that fits effortlessly into your apps",
-      "weight": 58958,
+      "weight": 59027,
       "image": "https://raw.githubusercontent.com/meilisearch/meilisearch/main/assets/logo.svg"
     },
     {
@@ -186,7 +186,7 @@
       "link": "https://typesense.org/",
       "name": "Typesense",
       "desc": "Open source, typo-tolerant search engine for building delightful search",
-      "weight": 26433,
+      "weight": 26457,
       "image": "https://avatars.githubusercontent.com/u/19822348?v=4"
     },
     {
@@ -197,7 +197,7 @@
       "link": "https://solr.apache.org/",
       "name": "Apache Solr",
       "desc": "Fast, open source search platform built on Apache Lucene",
-      "weight": 1654,
+      "weight": 1662,
       "image": "https://avatars.githubusercontent.com/u/47359?v=4"
     },
     {
@@ -208,7 +208,7 @@
       "link": "https://kafka.apache.org/",
       "name": "Apache Kafka",
       "desc": "Distributed event streaming platform",
-      "weight": 33536,
+      "weight": 33565,
       "image": "https://avatars.githubusercontent.com/u/47359?v=4"
     },
     {
@@ -219,7 +219,7 @@
       "link": "https://www.rabbitmq.com/",
       "name": "RabbitMQ",
       "desc": "Open source multi-protocol messaging broker",
-      "weight": 13779,
+      "weight": 13793,
       "image": "https://avatars.githubusercontent.com/u/96669?v=4"
     },
     {
@@ -230,7 +230,7 @@
       "link": "https://nats.io/",
       "name": "NATS Server",
       "desc": "High-performance server for NATS.io, the cloud native messaging system",
-      "weight": 20488,
+      "weight": 20550,
       "image": "https://avatars.githubusercontent.com/u/10203055?v=4"
     },
     {
@@ -241,7 +241,7 @@
       "link": "https://www.redpanda.com/",
       "name": "Redpanda",
       "desc": "Kafka-compatible streaming platform without ZooKeeper or JVM",
-      "weight": 12437,
+      "weight": 12463,
       "image": "https://avatars.githubusercontent.com/u/49406389?v=4"
     },
     {
@@ -263,7 +263,7 @@
       "link": "https://clickhouse.com/",
       "name": "ClickHouse",
       "desc": "Fast open-source column-oriented database management system",
-      "weight": 49227,
+      "weight": 49357,
       "image": "https://avatars.githubusercontent.com/u/54801242?v=4"
     },
     {
@@ -274,7 +274,7 @@
       "link": "https://duckdb.org/",
       "name": "DuckDB",
       "desc": "In-process analytical SQL database engine",
-      "weight": 40210,
+      "weight": 40460,
       "image": "https://avatars.githubusercontent.com/u/82039556?v=4"
     },
     {
@@ -285,7 +285,7 @@
       "link": "https://druid.apache.org/",
       "name": "Apache Druid",
       "desc": "High-performance, real-time analytics database",
-      "weight": 14041,
+      "weight": 14044,
       "image": "https://avatars.githubusercontent.com/u/47359?v=4"
     },
     {
@@ -296,7 +296,7 @@
       "link": "https://pinot.apache.org/",
       "name": "Apache Pinot",
       "desc": "Realtime distributed OLAP datastore for low-latency analytics",
-      "weight": 6123,
+      "weight": 6122,
       "image": "https://avatars.githubusercontent.com/u/47359?v=4"
     },
     {
@@ -307,7 +307,7 @@
       "link": "https://www.influxdata.com/",
       "name": "InfluxDB",
       "desc": "Scalable datastore for metrics, events, and real-time analytics",
-      "weight": 31690,
+      "weight": 31706,
       "image": "https://avatars.githubusercontent.com/u/5713248?v=4"
     },
     {
@@ -318,7 +318,7 @@
       "link": "https://www.timescale.com/",
       "name": "TimescaleDB",
       "desc": "Open-source time-series database built on PostgreSQL",
-      "weight": 23319,
+      "weight": 23378,
       "image": "https://avatars.githubusercontent.com/u/8986001?v=4"
     },
     {
@@ -329,7 +329,7 @@
       "link": "https://questdb.io/",
       "name": "QuestDB",
       "desc": "High-performance time-series database for fast ingest and SQL queries",
-      "weight": 17255,
+      "weight": 17267,
       "image": "https://avatars.githubusercontent.com/u/52297642?v=4"
     },
     {
@@ -340,7 +340,7 @@
       "link": "https://neo4j.com/",
       "name": "Neo4j",
       "desc": "Graphs for everyone, native graph database",
-      "weight": 17057,
+      "weight": 17091,
       "image": "https://avatars.githubusercontent.com/u/201120?v=4"
     },
     {
@@ -351,7 +351,7 @@
       "link": "https://dgraph.io/",
       "name": "Dgraph",
       "desc": "Native GraphQL database with a graph backend",
-      "weight": 21772,
+      "weight": 21779,
       "image": "https://raw.githubusercontent.com/dgraph-io/dgraph/main/logo.png"
     },
     {
@@ -362,7 +362,7 @@
       "link": "https://www.arangodb.com/",
       "name": "ArangoDB",
       "desc": "Multi-model database for graph, document, and key-value data",
-      "weight": 14260,
+      "weight": 14259,
       "image": "https://avatars.githubusercontent.com/u/5547849?v=4"
     },
     {
@@ -373,7 +373,7 @@
       "link": "https://hibernate.org/orm/",
       "name": "Hibernate ORM",
       "desc": "Object/relational mapping for Java",
-      "weight": 6472,
+      "weight": 6461,
       "image": "https://avatars.githubusercontent.com/u/348262?v=4"
     },
     {
@@ -384,7 +384,7 @@
       "link": "https://orm.drizzle.team/",
       "name": "Drizzle ORM",
       "desc": "TypeScript ORM with a head-first, SQL-like API",
-      "weight": 35462,
+      "weight": 35527,
       "image": "https://avatars.githubusercontent.com/u/108468352?v=4"
     },
     {
@@ -395,7 +395,7 @@
       "link": "https://gorm.io/",
       "name": "GORM",
       "desc": "The fantastic ORM library for Golang",
-      "weight": 39912,
+      "weight": 39913,
       "image": "https://avatars.githubusercontent.com/u/15127678?v=4"
     },
     {
@@ -406,7 +406,7 @@
       "link": "https://sequelize.org/",
       "name": "Sequelize",
       "desc": "Feature-rich ORM for Node.js compatible with many SQL dialects",
-      "weight": 30377,
+      "weight": 30371,
       "image": "https://raw.githubusercontent.com/sequelize/sequelize/main/logo.svg"
     },
     {
@@ -417,7 +417,7 @@
       "link": "https://www.sqlalchemy.org/",
       "name": "SQLAlchemy",
       "desc": "The Python SQL toolkit and object relational mapper",
-      "weight": 12078,
+      "weight": 12094,
       "image": "https://avatars.githubusercontent.com/u/6043126?v=4"
     },
     {
@@ -428,7 +428,7 @@
       "link": "https://dbeaver.io/",
       "name": "DBeaver",
       "desc": "Free universal database tool and SQL client",
-      "weight": 51445,
+      "weight": 51486,
       "image": "https://avatars.githubusercontent.com/u/34743864?v=4"
     },
     {
@@ -439,7 +439,7 @@
       "link": "https://www.adminer.org/",
       "name": "Adminer",
       "desc": "Database management in a single PHP file",
-      "weight": 7752
+      "weight": 7812
     },
     {
       "id": "flyway/flyway",
@@ -449,7 +449,7 @@
       "link": "https://flywaydb.org/",
       "name": "Flyway",
       "desc": "Database migrations made easy",
-      "weight": 9991,
+      "weight": 10017,
       "image": "https://avatars.githubusercontent.com/u/2109532?v=4"
     },
     {
@@ -460,7 +460,7 @@
       "link": "https://www.liquibase.com/",
       "name": "Liquibase",
       "desc": "Version control for database schema change management",
-      "weight": 5585,
+      "weight": 5591,
       "image": "https://avatars.githubusercontent.com/u/438548?v=4"
     },
     {
@@ -471,7 +471,7 @@
       "link": "https://airflow.apache.org/",
       "name": "Apache Airflow",
       "desc": "Platform to programmatically author, schedule, and monitor workflows",
-      "weight": 46465,
+      "weight": 46547,
       "image": "https://avatars.githubusercontent.com/u/47359?v=4"
     },
     {
@@ -482,7 +482,7 @@
       "link": "https://www.getdbt.com/",
       "name": "dbt Core",
       "desc": "Transform data in your warehouse using SQL",
-      "weight": 13636,
+      "weight": 13667,
       "image": "https://avatars.githubusercontent.com/u/18339788?v=4"
     },
     {
@@ -493,7 +493,7 @@
       "link": "https://meltano.com/",
       "name": "Meltano",
       "desc": "Open source data movement and ELT platform",
-      "weight": 2591,
+      "weight": 2598,
       "image": "https://avatars.githubusercontent.com/u/43816713?v=4"
     },
     {
@@ -504,7 +504,7 @@
       "link": "https://nifi.apache.org/",
       "name": "Apache NiFi",
       "desc": "Easy-to-use, powerful system to process and distribute data",
-      "weight": 6191,
+      "weight": 6200,
       "image": "https://avatars.githubusercontent.com/u/47359?v=4"
     },
     {
@@ -515,7 +515,7 @@
       "link": "https://www.metabase.com/",
       "name": "Metabase",
       "desc": "The simplest, fastest way to get business intelligence and analytics",
-      "weight": 48745,
+      "weight": 48848,
       "image": "https://avatars.githubusercontent.com/u/10520629?v=4"
     },
     {
@@ -526,7 +526,7 @@
       "link": "https://superset.apache.org/",
       "name": "Apache Superset",
       "desc": "Modern data exploration and visualization platform",
-      "weight": 74251,
+      "weight": 74321,
       "image": "https://avatars.githubusercontent.com/u/47359?v=4"
     },
     {
@@ -537,8 +537,19 @@
       "link": "https://redash.io/",
       "name": "Redash",
       "desc": "Connect and query data sources, build dashboards to share",
-      "weight": 28744,
+      "weight": 28759,
       "image": "https://avatars.githubusercontent.com/u/10746780?v=4"
+    },
+    {
+      "id": "neondatabase/neon",
+      "path": [
+        "Relational Databases"
+      ],
+      "link": "https://neon.tech",
+      "name": "Neon",
+      "desc": "Serverless Postgres with autoscaling and instant branching",
+      "weight": 22908,
+      "image": "https://avatars.githubusercontent.com/u/77690634?v=4"
     }
   ]
 }

--- a/data/devops-infra.json
+++ b/data/devops-infra.json
@@ -11,7 +11,7 @@
       "link": "https://www.docker.com/",
       "name": "Docker",
       "desc": "An open platform for developing, shipping, and running applications in containers",
-      "weight": 72007,
+      "weight": 71986,
       "image": "https://avatars.githubusercontent.com/u/27259197?v=4"
     },
     {
@@ -22,7 +22,7 @@
       "link": "https://docs.docker.com/compose/",
       "name": "Docker Compose",
       "desc": "Define and run multi-container applications with Docker",
-      "weight": 38075,
+      "weight": 38047,
       "image": "https://raw.githubusercontent.com/docker/compose/main/logo.png"
     },
     {
@@ -33,7 +33,7 @@
       "link": "https://containerd.io/",
       "name": "containerd",
       "desc": "An industry-standard container runtime with an emphasis on simplicity, robustness, and portability",
-      "weight": 21110,
+      "weight": 21135,
       "image": "https://avatars.githubusercontent.com/u/14037953?v=4"
     },
     {
@@ -44,7 +44,7 @@
       "link": "https://podman.io/",
       "name": "Podman",
       "desc": "A daemonless container engine for developing, managing, and running OCI containers",
-      "weight": 32548,
+      "weight": 32639,
       "image": "https://avatars.githubusercontent.com/u/277799342?v=4"
     },
     {
@@ -55,7 +55,7 @@
       "link": "https://buildah.io/",
       "name": "Buildah",
       "desc": "A tool for building OCI container images",
-      "weight": 8977,
+      "weight": 8991,
       "image": "https://avatars.githubusercontent.com/u/277799342?v=4"
     },
     {
@@ -66,7 +66,7 @@
       "link": "https://kubernetes.io/",
       "name": "Kubernetes",
       "desc": "Production-grade container orchestration",
-      "weight": 124462,
+      "weight": 124617,
       "image": "https://avatars.githubusercontent.com/u/13629408?v=4"
     },
     {
@@ -77,7 +77,7 @@
       "link": "https://github.com/moby/swarmkit",
       "name": "SwarmKit",
       "desc": "A toolkit for orchestrating distributed systems at any scale, with node discovery, raft-based consensus, and task scheduling",
-      "weight": 3644,
+      "weight": 3645,
       "image": "https://avatars.githubusercontent.com/u/27259197?v=4"
     },
     {
@@ -88,7 +88,7 @@
       "link": "https://www.nomadproject.io/",
       "name": "Nomad",
       "desc": "A simple and flexible workload orchestrator to deploy and manage containers and non-containerized applications",
-      "weight": 16799,
+      "weight": 16813,
       "image": "https://avatars.githubusercontent.com/u/761456?v=4"
     },
     {
@@ -99,7 +99,7 @@
       "link": "https://www.rancher.com/",
       "name": "Rancher",
       "desc": "Complete container management platform for Kubernetes",
-      "weight": 25846,
+      "weight": 25861,
       "image": "https://avatars.githubusercontent.com/u/9343010?v=4"
     },
     {
@@ -110,7 +110,7 @@
       "link": "https://k3s.io/",
       "name": "K3s",
       "desc": "Lightweight Kubernetes distribution built for edge, IoT, and CI",
-      "weight": 33726,
+      "weight": 33766,
       "image": "https://avatars.githubusercontent.com/u/49319725?v=4"
     },
     {
@@ -121,7 +121,7 @@
       "link": "https://www.jenkins.io/",
       "name": "Jenkins",
       "desc": "An extensible open source automation server",
-      "weight": 26450,
+      "weight": 26476,
       "image": "https://avatars.githubusercontent.com/u/107424?v=4"
     },
     {
@@ -132,7 +132,7 @@
       "link": "https://woodpecker-ci.org/",
       "name": "Woodpecker CI",
       "desc": "A simple, yet powerful CI/CD engine with great extensibility",
-      "weight": 7670,
+      "weight": 7723,
       "image": "https://avatars.githubusercontent.com/u/84780935?v=4"
     },
     {
@@ -143,7 +143,7 @@
       "link": "https://concourse-ci.org/",
       "name": "Concourse",
       "desc": "A container-based continuous thing-doer",
-      "weight": 7885,
+      "weight": 7892,
       "image": "https://avatars.githubusercontent.com/u/7809479?v=4"
     },
     {
@@ -154,7 +154,7 @@
       "link": "https://tekton.dev/",
       "name": "Tekton Pipelines",
       "desc": "Kubernetes-native, cloud-native CI/CD pipelines",
-      "weight": 9034,
+      "weight": 9037,
       "image": "https://avatars.githubusercontent.com/u/47602533?v=4"
     },
     {
@@ -165,7 +165,7 @@
       "link": "https://spinnaker.io/",
       "name": "Spinnaker",
       "desc": "An open source, multi-cloud continuous delivery platform",
-      "weight": 9763,
+      "weight": 9770,
       "image": "https://avatars.githubusercontent.com/u/7634182?v=4"
     },
     {
@@ -176,7 +176,7 @@
       "link": "https://www.terraform.io/",
       "name": "Terraform",
       "desc": "Write, plan, and create infrastructure as code",
-      "weight": 49482,
+      "weight": 49496,
       "image": "https://avatars.githubusercontent.com/u/761456?v=4"
     },
     {
@@ -187,7 +187,7 @@
       "link": "https://opentofu.org/",
       "name": "OpenTofu",
       "desc": "An open source, community-driven fork of Terraform",
-      "weight": 29769,
+      "weight": 29846,
       "image": "https://avatars.githubusercontent.com/u/142061836?v=4"
     },
     {
@@ -198,7 +198,7 @@
       "link": "https://www.pulumi.com/",
       "name": "Pulumi",
       "desc": "Infrastructure as code in any programming language",
-      "weight": 25561,
+      "weight": 25589,
       "image": "https://avatars.githubusercontent.com/u/21992475?v=4"
     },
     {
@@ -209,7 +209,7 @@
       "link": "https://www.packer.io/",
       "name": "Packer",
       "desc": "A tool for building identical machine images for multiple platforms from a single source configuration",
-      "weight": 15752,
+      "weight": 15763,
       "image": "https://avatars.githubusercontent.com/u/761456?v=4"
     },
     {
@@ -220,7 +220,7 @@
       "link": "https://aws.amazon.com/cdk/",
       "name": "AWS CDK",
       "desc": "An open source software development framework to define cloud infrastructure in code",
-      "weight": 12863,
+      "weight": 12871,
       "image": "https://avatars.githubusercontent.com/u/2232217?v=4"
     },
     {
@@ -231,7 +231,7 @@
       "link": "https://www.ansible.com/",
       "name": "Ansible",
       "desc": "A radically simple IT automation platform",
-      "weight": 70333,
+      "weight": 70402,
       "image": "https://avatars.githubusercontent.com/u/1507452?v=4"
     },
     {
@@ -242,7 +242,7 @@
       "link": "https://www.puppet.com/",
       "name": "Puppet",
       "desc": "Server automation framework and application",
-      "weight": 7919,
+      "weight": 7922,
       "image": "https://avatars.githubusercontent.com/u/234268?v=4"
     },
     {
@@ -253,7 +253,7 @@
       "link": "https://www.chef.io/",
       "name": "Chef",
       "desc": "A configuration management tool for infrastructure automation",
-      "weight": 8231,
+      "weight": 8225,
       "image": "https://avatars.githubusercontent.com/u/29740?v=4"
     },
     {
@@ -264,7 +264,7 @@
       "link": "https://saltproject.io/",
       "name": "Salt",
       "desc": "Software to automate the management and configuration of any infrastructure or application at scale",
-      "weight": 15612,
+      "weight": 15626,
       "image": "https://avatars.githubusercontent.com/u/1147473?v=4"
     },
     {
@@ -286,7 +286,7 @@
       "link": "https://prometheus.io/",
       "name": "Prometheus",
       "desc": "The Prometheus monitoring system and time series database",
-      "weight": 65717,
+      "weight": 65762,
       "image": "https://avatars.githubusercontent.com/u/3380462?v=4"
     },
     {
@@ -297,7 +297,7 @@
       "link": "https://grafana.com/",
       "name": "Grafana",
       "desc": "The open observability platform for metrics, logs, and traces",
-      "weight": 76262,
+      "weight": 76327,
       "image": "https://avatars.githubusercontent.com/u/7195757?v=4"
     },
     {
@@ -308,7 +308,7 @@
       "link": "https://www.netdata.cloud/",
       "name": "Netdata",
       "desc": "Real-time performance monitoring, done right",
-      "weight": 80150,
+      "weight": 80240,
       "image": "https://avatars.githubusercontent.com/u/43390781?v=4"
     },
     {
@@ -319,7 +319,7 @@
       "link": "https://www.zabbix.com/",
       "name": "Zabbix",
       "desc": "An enterprise-class open source monitoring solution for networks and applications",
-      "weight": 6247,
+      "weight": 6290,
       "image": "https://avatars.githubusercontent.com/u/4561226?v=4"
     },
     {
@@ -330,7 +330,7 @@
       "link": "https://victoriametrics.com/",
       "name": "VictoriaMetrics",
       "desc": "Fast, cost-effective monitoring solution and time series database",
-      "weight": 17521,
+      "weight": 17573,
       "image": "https://avatars.githubusercontent.com/u/43720803?v=4"
     },
     {
@@ -341,7 +341,7 @@
       "link": "https://www.elastic.co/logstash/",
       "name": "Logstash",
       "desc": "A server-side data processing pipeline for ingesting, transforming, and shipping logs",
-      "weight": 14916,
+      "weight": 14926,
       "image": "https://avatars.githubusercontent.com/u/6764390?v=4"
     },
     {
@@ -352,7 +352,7 @@
       "link": "https://www.fluentd.org/",
       "name": "Fluentd",
       "desc": "An open source data collector for unified logging layers",
-      "weight": 13577,
+      "weight": 13578,
       "image": "https://avatars.githubusercontent.com/u/859518?v=4"
     },
     {
@@ -363,7 +363,7 @@
       "link": "https://fluentbit.io/",
       "name": "Fluent Bit",
       "desc": "Fast and lightweight logs and metrics processor and forwarder",
-      "weight": 8026,
+      "weight": 8048,
       "image": "https://avatars.githubusercontent.com/u/859518?v=4"
     },
     {
@@ -374,7 +374,7 @@
       "link": "https://grafana.com/oss/loki/",
       "name": "Loki",
       "desc": "Like Prometheus, but for logs",
-      "weight": 28721,
+      "weight": 28765,
       "image": "https://avatars.githubusercontent.com/u/7195757?v=4"
     },
     {
@@ -385,7 +385,7 @@
       "link": "https://www.graylog.org/",
       "name": "Graylog",
       "desc": "Free and open log management for centralized, streamlined log analysis",
-      "weight": 8111,
+      "weight": 8114,
       "image": "https://avatars.githubusercontent.com/u/474892?v=4"
     },
     {
@@ -396,7 +396,7 @@
       "link": "https://istio.io/",
       "name": "Istio",
       "desc": "Connect, secure, control, and observe services",
-      "weight": 38353,
+      "weight": 38354,
       "image": "https://avatars.githubusercontent.com/u/23534644?v=4"
     },
     {
@@ -407,7 +407,7 @@
       "link": "https://linkerd.io/",
       "name": "Linkerd",
       "desc": "Ultralight, security-first service mesh for Kubernetes",
-      "weight": 11477,
+      "weight": 11478,
       "image": "https://avatars.githubusercontent.com/u/25301026?v=4"
     },
     {
@@ -418,7 +418,7 @@
       "link": "https://www.envoyproxy.io/",
       "name": "Envoy",
       "desc": "Cloud-native high-performance edge/middle/service proxy",
-      "weight": 28770,
+      "weight": 28803,
       "image": "https://avatars.githubusercontent.com/u/30125649?v=4"
     },
     {
@@ -429,7 +429,7 @@
       "link": "https://www.consul.io/",
       "name": "Consul",
       "desc": "Service networking across any cloud or runtime",
-      "weight": 30031,
+      "weight": 30034,
       "image": "https://avatars.githubusercontent.com/u/761456?v=4"
     },
     {
@@ -440,7 +440,7 @@
       "link": "https://cilium.io/",
       "name": "Cilium",
       "desc": "eBPF-based networking, observability, and security for Kubernetes",
-      "weight": 24918,
+      "weight": 24979,
       "image": "https://avatars.githubusercontent.com/u/21054566?v=4"
     },
     {
@@ -451,7 +451,7 @@
       "link": "https://argo-cd.readthedocs.io/",
       "name": "Argo CD",
       "desc": "Declarative, GitOps continuous delivery tool for Kubernetes",
-      "weight": 23906,
+      "weight": 23962,
       "image": "https://raw.githubusercontent.com/argoproj/argo-cd/master/docs/assets/logo.png"
     },
     {
@@ -462,7 +462,7 @@
       "link": "https://fluxcd.io/",
       "name": "Flux",
       "desc": "Open and extensible continuous delivery solution for Kubernetes, powered by GitOps",
-      "weight": 8328,
+      "weight": 8357,
       "image": "https://avatars.githubusercontent.com/u/52158677?v=4"
     },
     {
@@ -473,7 +473,7 @@
       "link": "https://argoproj.github.io/workflows/",
       "name": "Argo Workflows",
       "desc": "Container-native workflow engine for orchestrating parallel jobs on Kubernetes",
-      "weight": 16894,
+      "weight": 16918,
       "image": "https://raw.githubusercontent.com/argoproj/argo-workflows/main/docs/assets/logo.png"
     },
     {
@@ -495,7 +495,7 @@
       "link": "https://flagger.app/",
       "name": "Flagger",
       "desc": "Progressive delivery Kubernetes operator for canary, A/B, and blue/green deployments",
-      "weight": 5388,
+      "weight": 5390,
       "image": "https://avatars.githubusercontent.com/u/52158677?v=4"
     },
     {
@@ -506,7 +506,7 @@
       "link": "https://helm.sh/",
       "name": "Helm",
       "desc": "The package manager for Kubernetes",
-      "weight": 30150,
+      "weight": 30157,
       "image": "https://avatars.githubusercontent.com/u/15859888?v=4"
     },
     {
@@ -517,7 +517,7 @@
       "link": "https://goharbor.io/",
       "name": "Harbor",
       "desc": "An open source trusted cloud native registry project that stores, signs, and scans content",
-      "weight": 29145,
+      "weight": 29191,
       "image": "https://avatars.githubusercontent.com/u/40275816?v=4"
     },
     {
@@ -528,7 +528,7 @@
       "link": "https://www.sonatype.com/products/sonatype-nexus-repository",
       "name": "Nexus Repository",
       "desc": "OSS repository manager supporting all major packaging formats",
-      "weight": 2616,
+      "weight": 2622,
       "image": "https://avatars.githubusercontent.com/u/44938?v=4"
     },
     {
@@ -539,7 +539,7 @@
       "link": "https://verdaccio.org/",
       "name": "Verdaccio",
       "desc": "A lightweight, private npm proxy registry",
-      "weight": 17826,
+      "weight": 17830,
       "image": "https://avatars.githubusercontent.com/u/18487506?v=4"
     },
     {
@@ -550,8 +550,52 @@
       "link": "https://goreleaser.com/",
       "name": "GoReleaser",
       "desc": "Deliver Go binaries as fast and easily as possible",
-      "weight": 15981,
+      "weight": 15994,
       "image": "https://avatars.githubusercontent.com/u/24697112?v=4"
+    },
+    {
+      "id": "nginx/nginx",
+      "path": [
+        "Reverse Proxy & Load Balancing"
+      ],
+      "link": "https://nginx.org/",
+      "name": "NGINX",
+      "desc": "High-performance HTTP server, reverse proxy, and load balancer",
+      "weight": 31457,
+      "image": "https://avatars.githubusercontent.com/u/1412239?v=4"
+    },
+    {
+      "id": "traefik/traefik",
+      "path": [
+        "Reverse Proxy & Load Balancing"
+      ],
+      "link": "https://traefik.io",
+      "name": "Traefik",
+      "desc": "Cloud-native reverse proxy and load balancer with automatic service discovery",
+      "weight": 64506,
+      "image": "https://avatars.githubusercontent.com/u/14280338?v=4"
+    },
+    {
+      "id": "backstage/backstage",
+      "path": [
+        "Developer Portals & Platform Engineering"
+      ],
+      "link": "https://backstage.io/",
+      "name": "Backstage",
+      "desc": "Open platform for building developer portals and internal tooling",
+      "weight": 34191,
+      "image": "https://avatars.githubusercontent.com/u/72526453?v=4"
+    },
+    {
+      "id": "open-telemetry/opentelemetry-collector",
+      "path": [
+        "Monitoring & Observability"
+      ],
+      "link": "https://opentelemetry.io",
+      "name": "OpenTelemetry Collector",
+      "desc": "Vendor-agnostic pipeline for collecting, processing, and exporting telemetry",
+      "weight": 7423,
+      "image": "https://avatars.githubusercontent.com/u/49998002?v=4"
     }
   ]
 }

--- a/data/security.json
+++ b/data/security.json
@@ -11,7 +11,7 @@
       "link": "https://nmap.org/",
       "name": "Nmap",
       "desc": "The Network Mapper - free network discovery and security auditing utility",
-      "weight": 13342,
+      "weight": 13394,
       "image": "https://avatars.githubusercontent.com/u/63385?v=4"
     },
     {
@@ -22,7 +22,7 @@
       "link": "https://github.com/robertdavidgraham/masscan",
       "name": "Masscan",
       "desc": "TCP port scanner that spews SYN packets asynchronously, scanning the entire Internet in under 5 minutes",
-      "weight": 25927
+      "weight": 25938
     },
     {
       "id": "zmap/zmap",
@@ -32,7 +32,7 @@
       "link": "https://zmap.io/",
       "name": "ZMap",
       "desc": "A fast single-packet network scanner designed for Internet-wide network surveys",
-      "weight": 6353,
+      "weight": 6359,
       "image": "https://avatars.githubusercontent.com/u/3345672?v=4"
     },
     {
@@ -43,7 +43,7 @@
       "link": "https://owasp.org/www-project-amass/",
       "name": "Amass",
       "desc": "In-depth attack surface mapping and asset discovery",
-      "weight": 14973,
+      "weight": 14997,
       "image": "https://avatars.githubusercontent.com/u/128647419?v=4"
     },
     {
@@ -54,7 +54,7 @@
       "link": "https://github.com/lanmaster53/recon-ng",
       "name": "Recon-ng",
       "desc": "Open source intelligence gathering tool aimed at reducing the time spent harvesting information from open sources",
-      "weight": 5846
+      "weight": 5860
     },
     {
       "id": "laramies/theHarvester",
@@ -64,7 +64,7 @@
       "link": "https://github.com/laramies/theHarvester",
       "name": "theHarvester",
       "desc": "E-mails, subdomains and names harvester - OSINT reconnaissance tool",
-      "weight": 17023
+      "weight": 17131
     },
     {
       "id": "greenbone/openvas-scanner",
@@ -74,7 +74,7 @@
       "link": "https://www.greenbone.net/en/community-edition/",
       "name": "OpenVAS Scanner",
       "desc": "The scanner component of Greenbone Community Edition, a full-featured vulnerability scanning engine",
-      "weight": 4766,
+      "weight": 4786,
       "image": "https://avatars.githubusercontent.com/u/31986857?v=4"
     },
     {
@@ -85,7 +85,7 @@
       "link": "https://cirt.net/Nikto2",
       "name": "Nikto",
       "desc": "Web server scanner that tests for dangerous files, outdated software, and other vulnerabilities",
-      "weight": 10645
+      "weight": 10674
     },
     {
       "id": "projectdiscovery/nuclei",
@@ -95,7 +95,7 @@
       "link": "https://nuclei.projectdiscovery.io/",
       "name": "Nuclei",
       "desc": "Fast, template-based vulnerability scanner for applications, APIs, networks, DNS, and cloud configurations",
-      "weight": 30470,
+      "weight": 30614,
       "image": "https://avatars.githubusercontent.com/u/50994705?v=4"
     },
     {
@@ -106,7 +106,7 @@
       "link": "https://wapiti-scanner.github.io/",
       "name": "Wapiti",
       "desc": "Web application vulnerability scanner written in Python",
-      "weight": 1837,
+      "weight": 1841,
       "image": "https://avatars.githubusercontent.com/u/66414381?v=4"
     },
     {
@@ -117,7 +117,7 @@
       "link": "https://www.zaproxy.org/",
       "name": "OWASP ZAP",
       "desc": "The world's most widely used web application scanner and intercepting proxy",
-      "weight": 15582,
+      "weight": 15644,
       "image": "https://avatars.githubusercontent.com/u/6716868?v=4"
     },
     {
@@ -128,7 +128,7 @@
       "link": "https://sqlmap.org/",
       "name": "sqlmap",
       "desc": "Automatic SQL injection and database takeover tool",
-      "weight": 38168,
+      "weight": 38227,
       "image": "https://avatars.githubusercontent.com/u/735289?v=4"
     },
     {
@@ -139,7 +139,7 @@
       "link": "https://dalfox.hahwul.com/",
       "name": "Dalfox",
       "desc": "Powerful open source XSS scanner and parameter analysis tool focused on automation",
-      "weight": 5224
+      "weight": 5240
     },
     {
       "id": "xmendez/wfuzz",
@@ -149,7 +149,7 @@
       "link": "https://github.com/xmendez/wfuzz",
       "name": "Wfuzz",
       "desc": "Web application fuzzer for brute-forcing parameters, forms, and directories",
-      "weight": 6551
+      "weight": 6555
     },
     {
       "id": "ffuf/ffuf",
@@ -159,7 +159,7 @@
       "link": "https://github.com/ffuf/ffuf",
       "name": "ffuf",
       "desc": "Fast web fuzzer written in Go",
-      "weight": 16522,
+      "weight": 16549,
       "image": "https://avatars.githubusercontent.com/u/42502069?v=4"
     },
     {
@@ -170,7 +170,7 @@
       "link": "https://www.metasploit.com/",
       "name": "Metasploit Framework",
       "desc": "Penetration testing and exploit development framework",
-      "weight": 38794,
+      "weight": 38832,
       "image": "https://avatars.githubusercontent.com/u/1013671?v=4"
     },
     {
@@ -181,7 +181,7 @@
       "link": "https://beefproject.com/",
       "name": "BeEF",
       "desc": "The Browser Exploitation Framework, focused on assessing web browser security",
-      "weight": 10975,
+      "weight": 10977,
       "image": "https://avatars.githubusercontent.com/u/1214850?v=4"
     },
     {
@@ -192,7 +192,7 @@
       "link": "https://github.com/BC-SECURITY/Empire",
       "name": "Empire",
       "desc": "Post-exploitation and adversary emulation framework used by red teams and penetration testers",
-      "weight": 5254,
+      "weight": 5257,
       "image": "https://avatars.githubusercontent.com/u/53022351?v=4"
     },
     {
@@ -203,7 +203,7 @@
       "link": "https://sliver.sh/",
       "name": "Sliver",
       "desc": "Open source adversary emulation and cross-platform command & control framework",
-      "weight": 11668,
+      "weight": 11702,
       "image": "https://avatars.githubusercontent.com/u/4523757?v=4"
     },
     {
@@ -214,7 +214,7 @@
       "link": "https://wazuh.com/",
       "name": "Wazuh",
       "desc": "Open source security platform providing unified XDR and SIEM protection for endpoints and cloud workloads",
-      "weight": 16509,
+      "weight": 16611,
       "image": "https://avatars.githubusercontent.com/u/13752566?v=4"
     },
     {
@@ -225,7 +225,7 @@
       "link": "https://www.ossec.net/",
       "name": "OSSEC",
       "desc": "Open source host-based intrusion detection system with log analysis, file integrity checking, and rootkit detection",
-      "weight": 5046,
+      "weight": 5044,
       "image": "https://avatars.githubusercontent.com/u/5479983?v=4"
     },
     {
@@ -236,7 +236,7 @@
       "link": "https://suricata.io/",
       "name": "Suricata",
       "desc": "Network intrusion detection, prevention, and security monitoring engine",
-      "weight": 6539,
+      "weight": 6558,
       "image": "https://avatars.githubusercontent.com/u/2188963?v=4"
     },
     {
@@ -247,7 +247,7 @@
       "link": "https://zeek.org/",
       "name": "Zeek",
       "desc": "Powerful network analysis framework focused on security monitoring",
-      "weight": 7872,
+      "weight": 7893,
       "image": "https://avatars.githubusercontent.com/u/1194067?v=4"
     },
     {
@@ -258,7 +258,7 @@
       "link": "https://securityonionsolutions.com/",
       "name": "Security Onion",
       "desc": "Free and open platform for threat hunting, enterprise security monitoring, and log management",
-      "weight": 4799,
+      "weight": 4834,
       "image": "https://avatars.githubusercontent.com/u/8959843?v=4"
     },
     {
@@ -269,7 +269,7 @@
       "link": "https://www.openwall.com/john/",
       "name": "John the Ripper",
       "desc": "Advanced offline password cracker supporting hundreds of hash and cipher types",
-      "weight": 13488,
+      "weight": 13519,
       "image": "https://avatars.githubusercontent.com/u/1579552?v=4"
     },
     {
@@ -280,7 +280,7 @@
       "link": "https://hashcat.net/hashcat/",
       "name": "Hashcat",
       "desc": "World's fastest and most advanced password recovery utility",
-      "weight": 26525,
+      "weight": 26583,
       "image": "https://avatars.githubusercontent.com/u/15949799?v=4"
     },
     {
@@ -291,7 +291,7 @@
       "link": "https://github.com/vanhauser-thc/thc-hydra",
       "name": "THC-Hydra",
       "desc": "Parallelized login cracker supporting numerous protocols to attack",
-      "weight": 12151
+      "weight": 12172
     },
     {
       "id": "Pennyw0rth/NetExec",
@@ -301,7 +301,7 @@
       "link": "https://www.netexec.wiki/",
       "name": "NetExec",
       "desc": "Network service exploitation tool for credential auditing across Active Directory environments",
-      "weight": 5777,
+      "weight": 5799,
       "image": "https://avatars.githubusercontent.com/u/144470396?v=4"
     },
     {
@@ -312,7 +312,7 @@
       "link": "http://foofus.net/goons/jmk/medusa/medusa.html",
       "name": "Medusa",
       "desc": "Speedy, parallel, and modular login brute-forcer",
-      "weight": 880
+      "weight": 881
     },
     {
       "id": "semgrep/semgrep",
@@ -322,7 +322,7 @@
       "link": "https://semgrep.dev/",
       "name": "Semgrep",
       "desc": "Lightweight static analysis tool for finding bugs and enforcing code standards across many languages",
-      "weight": 16194,
+      "weight": 16313,
       "image": "https://avatars.githubusercontent.com/u/29760937?v=4"
     },
     {
@@ -333,7 +333,7 @@
       "link": "https://bandit.readthedocs.io/",
       "name": "Bandit",
       "desc": "Tool designed to find common security issues in Python code",
-      "weight": 8209,
+      "weight": 8224,
       "image": "https://avatars.githubusercontent.com/u/8749848?v=4"
     },
     {
@@ -354,7 +354,7 @@
       "link": "https://codeql.github.com/",
       "name": "CodeQL",
       "desc": "Libraries and queries that power semantic code analysis for security research and code scanning",
-      "weight": 9930,
+      "weight": 9984,
       "image": "https://avatars.githubusercontent.com/u/9919?v=4"
     },
     {
@@ -365,7 +365,7 @@
       "link": "https://www.sonarsource.com/products/sonarqube/",
       "name": "SonarQube",
       "desc": "Continuous inspection platform for code quality and security analysis",
-      "weight": 10887,
+      "weight": 10910,
       "image": "https://avatars.githubusercontent.com/u/545988?v=4"
     },
     {
@@ -376,7 +376,7 @@
       "link": "https://www.vaultproject.io/",
       "name": "HashiCorp Vault",
       "desc": "Tool for secrets management, encryption as a service, and privileged access management",
-      "weight": 36112,
+      "weight": 36146,
       "image": "https://avatars.githubusercontent.com/u/761456?v=4"
     },
     {
@@ -387,7 +387,7 @@
       "link": "https://github.com/awslabs/git-secrets",
       "name": "git-secrets",
       "desc": "Prevents you from committing secrets and credentials into git repositories",
-      "weight": 13369,
+      "weight": 13377,
       "image": "https://avatars.githubusercontent.com/u/3299148?v=4"
     },
     {
@@ -398,7 +398,7 @@
       "link": "https://github.com/gitleaks/gitleaks",
       "name": "Gitleaks",
       "desc": "Scans git repositories, filesystems, and directories for hardcoded secrets and credentials",
-      "weight": 28648,
+      "weight": 28853,
       "image": "https://avatars.githubusercontent.com/u/90395851?v=4"
     },
     {
@@ -409,7 +409,7 @@
       "link": "https://trufflesecurity.com/trufflehog",
       "name": "TruffleHog",
       "desc": "Finds, verifies, and analyzes leaked credentials across git history and beyond",
-      "weight": 27410,
+      "weight": 27526,
       "image": "https://avatars.githubusercontent.com/u/79229934?v=4"
     },
     {
@@ -420,7 +420,7 @@
       "link": "https://github.com/getsops/sops",
       "name": "SOPS",
       "desc": "Simple and flexible tool for managing and encrypting secrets in files",
-      "weight": 22787,
+      "weight": 22866,
       "image": "https://avatars.githubusercontent.com/u/129185620?v=4"
     },
     {
@@ -431,7 +431,7 @@
       "link": "https://trivy.dev/",
       "name": "Trivy",
       "desc": "Finds vulnerabilities, misconfigurations, secrets, and SBOMs in containers, Kubernetes, and code repositories",
-      "weight": 37376,
+      "weight": 37520,
       "image": "https://avatars.githubusercontent.com/u/12783832?v=4"
     },
     {
@@ -442,7 +442,7 @@
       "link": "https://falco.org/",
       "name": "Falco",
       "desc": "Cloud-native runtime security tool for detecting anomalous activity in containers and hosts",
-      "weight": 9261,
+      "weight": 9287,
       "image": "https://avatars.githubusercontent.com/u/42391047?v=4"
     },
     {
@@ -453,7 +453,7 @@
       "link": "https://quay.github.io/clair/",
       "name": "Clair",
       "desc": "Static vulnerability analysis for application containers",
-      "weight": 11046,
+      "weight": 11049,
       "image": "https://avatars.githubusercontent.com/u/38353654?v=4"
     },
     {
@@ -464,7 +464,7 @@
       "link": "https://github.com/aquasecurity/kube-bench",
       "name": "kube-bench",
       "desc": "Checks whether Kubernetes is deployed according to security best practices from the CIS Kubernetes Benchmark",
-      "weight": 8139,
+      "weight": 8148,
       "image": "https://avatars.githubusercontent.com/u/12783832?v=4"
     },
     {
@@ -475,7 +475,7 @@
       "link": "https://prowler.com/",
       "name": "Prowler",
       "desc": "Open source cloud security platform that automates security and compliance checks across cloud environments",
-      "weight": 14573,
+      "weight": 14629,
       "image": "https://avatars.githubusercontent.com/u/97106991?v=4"
     },
     {
@@ -486,7 +486,7 @@
       "link": "https://github.com/nccgroup/ScoutSuite",
       "name": "Scout Suite",
       "desc": "Multi-cloud security auditing tool for assessing the security posture of cloud environments",
-      "weight": 7787,
+      "weight": 7793,
       "image": "https://avatars.githubusercontent.com/u/4067082?v=4"
     },
     {
@@ -497,7 +497,7 @@
       "link": "https://ghidra-sre.org/",
       "name": "Ghidra",
       "desc": "Software reverse engineering framework developed by the NSA",
-      "weight": 72286,
+      "weight": 72565,
       "image": "https://avatars.githubusercontent.com/u/11298292?v=4"
     },
     {
@@ -508,7 +508,7 @@
       "link": "https://rada.re/n/",
       "name": "Radare2",
       "desc": "UNIX-like reverse engineering framework and command-line toolset",
-      "weight": 24560,
+      "weight": 24608,
       "image": "https://avatars.githubusercontent.com/u/2842539?v=4"
     },
     {
@@ -519,7 +519,7 @@
       "link": "https://volatilityfoundation.org/",
       "name": "Volatility 3",
       "desc": "Memory forensics framework for extracting digital artifacts from volatile memory samples",
-      "weight": 4320,
+      "weight": 4336,
       "image": "https://avatars.githubusercontent.com/u/6001145?v=4"
     },
     {
@@ -530,7 +530,7 @@
       "link": "https://www.autopsy.com/",
       "name": "Autopsy",
       "desc": "Digital forensics platform and graphical interface to The Sleuth Kit and other forensics tools",
-      "weight": 3279,
+      "weight": 3288,
       "image": "https://avatars.githubusercontent.com/u/866922?v=4"
     },
     {
@@ -541,7 +541,7 @@
       "link": "https://www.sleuthkit.org/",
       "name": "The Sleuth Kit",
       "desc": "Library and collection of command line digital forensics tools for investigating volume and file system data",
-      "weight": 3124,
+      "weight": 3132,
       "image": "https://avatars.githubusercontent.com/u/866922?v=4"
     },
     {
@@ -552,8 +552,52 @@
       "link": "https://x64dbg.com/",
       "name": "x64dbg",
       "desc": "Open source user mode debugger for Windows, optimized for reverse engineering and malware analysis",
-      "weight": 49147,
+      "weight": 49202,
       "image": "https://avatars.githubusercontent.com/u/7937360?v=4"
+    },
+    {
+      "id": "wireshark/wireshark",
+      "path": [
+        "Network Scanning & Recon"
+      ],
+      "link": "https://www.wireshark.org",
+      "name": "Wireshark",
+      "desc": "Network protocol analyzer for capturing and inspecting traffic",
+      "weight": 9741,
+      "image": "https://avatars.githubusercontent.com/u/6233056?v=4"
+    },
+    {
+      "id": "VirusTotal/yara",
+      "path": [
+        "Forensics & Reverse Engineering"
+      ],
+      "link": "https://virustotal.github.io/yara/",
+      "name": "YARA",
+      "desc": "Pattern-matching tool for identifying and classifying malware",
+      "weight": 9814,
+      "image": "https://avatars.githubusercontent.com/u/7701252?v=4"
+    },
+    {
+      "id": "osquery/osquery",
+      "path": [
+        "SIEM & Threat Detection"
+      ],
+      "link": "https://osquery.io",
+      "name": "osquery",
+      "desc": "SQL-powered operating system instrumentation and monitoring",
+      "weight": 23478,
+      "image": "https://avatars.githubusercontent.com/u/8315868?v=4"
+    },
+    {
+      "id": "crowdsecurity/crowdsec",
+      "path": [
+        "SIEM & Threat Detection"
+      ],
+      "link": "https://crowdsec.net",
+      "name": "CrowdSec",
+      "desc": "Crowdsourced, behavior-based intrusion prevention system",
+      "weight": 14597,
+      "image": "https://avatars.githubusercontent.com/u/63284097?v=4"
     }
   ]
 }

--- a/data/smart-home.json
+++ b/data/smart-home.json
@@ -1,0 +1,454 @@
+{
+  "slug": "smart-home",
+  "name": "Best IoT & Smart Home Open Source Projects",
+  "description": "Home automation platforms, embedded firmware, robotics, and device protocols.",
+  "projects": [
+    {
+      "id": "home-assistant/core",
+      "path": [
+        "Home Automation Platforms"
+      ],
+      "link": "https://www.home-assistant.io",
+      "name": "Home Assistant",
+      "desc": "Open-source home automation that puts local control and privacy first",
+      "weight": 90003,
+      "image": "https://avatars.githubusercontent.com/u/13844975?v=4"
+    },
+    {
+      "id": "openhab/openhab-addons",
+      "path": [
+        "Home Automation Platforms"
+      ],
+      "link": "https://www.openhab.org/",
+      "name": "openHAB",
+      "desc": "Vendor- and technology-agnostic open-source home automation platform",
+      "weight": 2062,
+      "image": "https://raw.githubusercontent.com/openhab/openhab-addons/main/logo.png"
+    },
+    {
+      "id": "domoticz/domoticz",
+      "path": [
+        "Home Automation Platforms"
+      ],
+      "link": "https://www.domoticz.com",
+      "name": "Domoticz",
+      "desc": "Lightweight open-source home automation system",
+      "weight": 3793,
+      "image": "https://avatars.githubusercontent.com/u/6067010?v=4"
+    },
+    {
+      "id": "ioBroker/ioBroker",
+      "path": [
+        "Home Automation Platforms"
+      ],
+      "link": "http://iobroker.net",
+      "name": "ioBroker",
+      "desc": "Integration platform for the Internet of Things",
+      "weight": 1373,
+      "image": "https://avatars.githubusercontent.com/u/7231148?v=4"
+    },
+    {
+      "id": "homebridge/homebridge",
+      "path": [
+        "Home Automation Platforms"
+      ],
+      "link": "https://homebridge.io",
+      "name": "Homebridge",
+      "desc": "Bridges non-HomeKit smart home devices to Apple HomeKit",
+      "weight": 25456,
+      "image": "https://avatars.githubusercontent.com/u/38217527?v=4"
+    },
+    {
+      "id": "Koenkk/zigbee2mqtt",
+      "path": [
+        "Device Protocols & Telemetry"
+      ],
+      "link": "https://www.zigbee2mqtt.io",
+      "name": "Zigbee2MQTT",
+      "desc": "Bridges Zigbee devices to MQTT without a vendor hub",
+      "weight": 15513
+    },
+    {
+      "id": "project-chip/connectedhomeip",
+      "path": [
+        "Device Protocols & Telemetry"
+      ],
+      "link": "https://buildwithmatter.com",
+      "name": "Matter",
+      "desc": "Unified, royalty-free connectivity standard for smart home devices",
+      "weight": 8880,
+      "image": "https://avatars.githubusercontent.com/u/61027988?v=4"
+    },
+    {
+      "id": "eclipse-mosquitto/mosquitto",
+      "path": [
+        "Device Protocols & Telemetry"
+      ],
+      "link": "https://mosquitto.org",
+      "name": "Eclipse Mosquitto",
+      "desc": "Open-source MQTT message broker",
+      "weight": 11143,
+      "image": "https://avatars.githubusercontent.com/u/185921483?v=4"
+    },
+    {
+      "id": "zwave-js/zwave-js-ui",
+      "path": [
+        "Device Protocols & Telemetry"
+      ],
+      "link": "https://zwave-js.github.io/zwave-js-ui",
+      "name": "Z-Wave JS UI",
+      "desc": "Full-featured web UI for Z-Wave JS",
+      "weight": 1235,
+      "image": "https://avatars.githubusercontent.com/u/54627315?v=4"
+    },
+    {
+      "id": "influxdata/telegraf",
+      "path": [
+        "Device Protocols & Telemetry"
+      ],
+      "link": "https://influxdata.com/telegraf",
+      "name": "Telegraf",
+      "desc": "Agent for collecting, processing, and writing metrics and telemetry",
+      "weight": 17760,
+      "image": "https://avatars.githubusercontent.com/u/5713248?v=4"
+    },
+    {
+      "id": "node-red/node-red",
+      "path": [
+        "Automation Rules & Dashboards"
+      ],
+      "link": "http://nodered.org",
+      "name": "Node-RED",
+      "desc": "Low-code, flow-based programming tool for wiring together APIs and devices",
+      "weight": 23553,
+      "image": "https://avatars.githubusercontent.com/u/5375661?v=4"
+    },
+    {
+      "id": "thingsboard/thingsboard",
+      "path": [
+        "Automation Rules & Dashboards"
+      ],
+      "link": "https://thingsboard.io",
+      "name": "ThingsBoard",
+      "desc": "Open-source IoT platform for device management and data visualization",
+      "weight": 22285,
+      "image": "https://avatars.githubusercontent.com/u/24291394?v=4"
+    },
+    {
+      "id": "openremote/openremote",
+      "path": [
+        "Automation Rules & Dashboards"
+      ],
+      "link": "https://openremote.io",
+      "name": "OpenRemote",
+      "desc": "Open-source IoT platform for integrating devices and building custom apps",
+      "weight": 1874,
+      "image": "https://avatars.githubusercontent.com/u/4995595?v=4"
+    },
+    {
+      "id": "n8n-io/n8n",
+      "path": [
+        "Automation Rules & Dashboards"
+      ],
+      "link": "https://n8n.io",
+      "name": "n8n",
+      "desc": "Fair-code workflow automation platform with native AI capabilities",
+      "weight": 201299,
+      "image": "https://avatars.githubusercontent.com/u/45487711?v=4"
+    },
+    {
+      "id": "arendst/Tasmota",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "https://tasmota.github.io/docs",
+      "name": "Tasmota",
+      "desc": "Alternative firmware for ESP8266/ESP32 devices with local MQTT control",
+      "weight": 24717
+    },
+    {
+      "id": "esphome/esphome",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "https://esphome.io/",
+      "name": "ESPHome",
+      "desc": "System for controlling ESP32/ESP8266 devices through simple configuration files",
+      "weight": 11565,
+      "image": "https://avatars.githubusercontent.com/u/45919759?v=4"
+    },
+    {
+      "id": "espressif/esp-idf",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "https://github.com/espressif/esp-idf",
+      "name": "ESP-IDF",
+      "desc": "Official development framework for Espressif SoCs",
+      "weight": 18822,
+      "image": "https://avatars.githubusercontent.com/u/9460735?v=4"
+    },
+    {
+      "id": "zephyrproject-rtos/zephyr",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "https://docs.zephyrproject.org",
+      "name": "Zephyr",
+      "desc": "Scalable real-time operating system for connected, resource-constrained devices",
+      "weight": 16262,
+      "image": "https://avatars.githubusercontent.com/u/19595895?v=4"
+    },
+    {
+      "id": "platformio/platformio-core",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "https://platformio.org",
+      "name": "PlatformIO",
+      "desc": "Professional toolchain for embedded software development",
+      "weight": 9412,
+      "image": "https://avatars.githubusercontent.com/u/11621357?v=4"
+    },
+    {
+      "id": "RIOT-OS/RIOT",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "https://riot-os.org",
+      "name": "RIOT",
+      "desc": "Friendly operating system for the Internet of Things",
+      "weight": 5776,
+      "image": "https://avatars.githubusercontent.com/u/3079480?v=4"
+    },
+    {
+      "id": "apache/nuttx",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "https://nuttx.apache.org/",
+      "name": "Apache NuttX",
+      "desc": "Mature, real-time embedded operating system",
+      "weight": 4002,
+      "image": "https://avatars.githubusercontent.com/u/47359?v=4"
+    },
+    {
+      "id": "micropython/micropython",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "https://micropython.org",
+      "name": "MicroPython",
+      "desc": "Lean and efficient Python implementation for microcontrollers",
+      "weight": 21999,
+      "image": "https://avatars.githubusercontent.com/u/6298560?v=4"
+    },
+    {
+      "id": "arduino/Arduino",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "https://www.arduino.cc/en/software",
+      "name": "Arduino IDE",
+      "desc": "Open-source electronics platform for building interactive hardware projects",
+      "weight": 14638,
+      "image": "https://avatars.githubusercontent.com/u/379109?v=4"
+    },
+    {
+      "id": "espruino/Espruino",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "http://www.espruino.com/",
+      "name": "Espruino",
+      "desc": "JavaScript interpreter for microcontrollers",
+      "weight": 2964,
+      "image": "https://avatars.githubusercontent.com/u/5548236?v=4"
+    },
+    {
+      "id": "letscontrolit/ESPEasy",
+      "path": [
+        "Embedded Firmware & Dev Platforms"
+      ],
+      "link": "http://www.espeasy.com",
+      "name": "ESPEasy",
+      "desc": "Easy multi-sensor firmware for ESP8266/ESP32 devices",
+      "weight": 3564,
+      "image": "https://avatars.githubusercontent.com/u/23070406?v=4"
+    },
+    {
+      "id": "rhasspy/rhasspy",
+      "path": [
+        "Voice Assistants"
+      ],
+      "link": "https://community.rhasspy.org/",
+      "name": "Rhasspy",
+      "desc": "Offline, privacy-focused voice assistant toolkit",
+      "weight": 2751,
+      "image": "https://avatars.githubusercontent.com/u/59055969?v=4"
+    },
+    {
+      "id": "MycroftAI/mycroft-core",
+      "path": [
+        "Voice Assistants"
+      ],
+      "link": "https://mycroft.ai",
+      "name": "Mycroft",
+      "desc": "Open-source voice assistant platform",
+      "weight": 6610,
+      "image": "https://avatars.githubusercontent.com/u/14171097?v=4"
+    },
+    {
+      "id": "ros2/ros2",
+      "path": [
+        "Robotics & Autonomous Systems"
+      ],
+      "link": "https://docs.ros.org",
+      "name": "ROS 2",
+      "desc": "Meta operating system for building robot applications",
+      "weight": 5914,
+      "image": "https://avatars.githubusercontent.com/u/3979232?v=4"
+    },
+    {
+      "id": "ros/ros",
+      "path": [
+        "Robotics & Autonomous Systems"
+      ],
+      "link": "http://www.ros.org",
+      "name": "ROS",
+      "desc": "Flexible framework for writing robot software",
+      "weight": 3249,
+      "image": "https://avatars.githubusercontent.com/u/547448?v=4"
+    },
+    {
+      "id": "PX4/PX4-Autopilot",
+      "path": [
+        "Robotics & Autonomous Systems"
+      ],
+      "link": "https://px4.io",
+      "name": "PX4",
+      "desc": "Open-source flight control software for drones and other autonomous vehicles",
+      "weight": 12450,
+      "image": "https://avatars.githubusercontent.com/u/2096014?v=4"
+    },
+    {
+      "id": "ArduPilot/ardupilot",
+      "path": [
+        "Robotics & Autonomous Systems"
+      ],
+      "link": "http://ardupilot.org/",
+      "name": "ArduPilot",
+      "desc": "Open-source autopilot software for drones, rovers, and submarines",
+      "weight": 15712,
+      "image": "https://avatars.githubusercontent.com/u/17919847?v=4"
+    },
+    {
+      "id": "gazebosim/gz-sim",
+      "path": [
+        "Robotics & Autonomous Systems"
+      ],
+      "link": "https://gazebosim.org",
+      "name": "Gazebo",
+      "desc": "Open-source robotics simulator",
+      "weight": 1452,
+      "image": "https://avatars.githubusercontent.com/u/1743799?v=4"
+    },
+    {
+      "id": "microsoft/AirSim",
+      "path": [
+        "Robotics & Autonomous Systems"
+      ],
+      "link": "https://microsoft.github.io/AirSim/",
+      "name": "AirSim",
+      "desc": "Open-source simulator for drones and autonomous vehicles",
+      "weight": 18411,
+      "image": "https://avatars.githubusercontent.com/u/6154722?v=4"
+    },
+    {
+      "id": "blakeblackshear/frigate",
+      "path": [
+        "Camera & Security Automation"
+      ],
+      "link": "https://frigate.video",
+      "name": "Frigate",
+      "desc": "NVR with real-time local object detection for IP cameras",
+      "weight": 35246
+    },
+    {
+      "id": "ZoneMinder/zoneminder",
+      "path": [
+        "Camera & Security Automation"
+      ],
+      "link": "http://www.zoneminder.com/",
+      "name": "ZoneMinder",
+      "desc": "Open-source video surveillance and security camera platform",
+      "weight": 5913,
+      "image": "https://avatars.githubusercontent.com/u/4137646?v=4"
+    },
+    {
+      "id": "AlexxIT/go2rtc",
+      "path": [
+        "Camera & Security Automation"
+      ],
+      "link": "https://go2rtc.org",
+      "name": "go2rtc",
+      "desc": "Camera streaming application supporting multiple protocols",
+      "weight": 13999
+    },
+    {
+      "id": "Klipper3d/klipper",
+      "path": [
+        "3D Printing & Fabrication"
+      ],
+      "link": "https://github.com/Klipper3d/klipper",
+      "name": "Klipper",
+      "desc": "3D printer firmware for fast, high-precision printing",
+      "weight": 11823,
+      "image": "https://avatars.githubusercontent.com/u/90982958?v=4"
+    },
+    {
+      "id": "prusa3d/PrusaSlicer",
+      "path": [
+        "3D Printing & Fabrication"
+      ],
+      "link": "https://www.prusa3d.com/prusaslicer/",
+      "name": "PrusaSlicer",
+      "desc": "G-code generator and slicer for 3D printers",
+      "weight": 9241,
+      "image": "https://avatars.githubusercontent.com/u/14859759?v=4"
+    },
+    {
+      "id": "Ultimaker/Cura",
+      "path": [
+        "3D Printing & Fabrication"
+      ],
+      "link": "https://github.com/Ultimaker/Cura",
+      "name": "Cura",
+      "desc": "Slicing application for preparing 3D models for printing",
+      "weight": 7015,
+      "image": "https://avatars.githubusercontent.com/u/499557?v=4"
+    },
+    {
+      "id": "MarlinFirmware/Marlin",
+      "path": [
+        "3D Printing & Fabrication"
+      ],
+      "link": "https://marlinfw.org",
+      "name": "Marlin",
+      "desc": "Firmware for RepRap 3D printers",
+      "weight": 17545,
+      "image": "https://avatars.githubusercontent.com/u/10418365?v=4"
+    },
+    {
+      "id": "OrcaSlicer/OrcaSlicer",
+      "path": [
+        "3D Printing & Fabrication"
+      ],
+      "link": "https://www.orcaslicer.com",
+      "name": "OrcaSlicer",
+      "desc": "G-code generator and slicer for 3D printers",
+      "weight": 15433,
+      "image": "https://avatars.githubusercontent.com/u/134699248?v=4"
+    }
+  ]
+}

--- a/data/web-dev.json
+++ b/data/web-dev.json
@@ -11,7 +11,7 @@
       "link": "https://react.dev",
       "name": "React",
       "desc": "A JavaScript library for building user interfaces",
-      "weight": 247202,
+      "weight": 247434,
       "image": "https://avatars.githubusercontent.com/u/102812?v=4"
     },
     {
@@ -22,7 +22,7 @@
       "link": "https://vuejs.org",
       "name": "Vue",
       "desc": "The Progressive JavaScript Framework",
-      "weight": 54222,
+      "weight": 54218,
       "image": "https://avatars.githubusercontent.com/u/6128107?v=4"
     },
     {
@@ -33,7 +33,7 @@
       "link": "https://svelte.dev",
       "name": "Svelte",
       "desc": "Cybernetically enhanced web apps",
-      "weight": 87968,
+      "weight": 87979,
       "image": "https://avatars.githubusercontent.com/u/23617963?v=4"
     },
     {
@@ -44,7 +44,7 @@
       "link": "https://angular.dev",
       "name": "Angular",
       "desc": "The modern web developer's platform",
-      "weight": 100994,
+      "weight": 101005,
       "image": "https://avatars.githubusercontent.com/u/139426?v=4"
     },
     {
@@ -55,7 +55,7 @@
       "link": "https://www.solidjs.com",
       "name": "Solid",
       "desc": "A declarative, efficient, and flexible library for building user interfaces",
-      "weight": 35814,
+      "weight": 35878,
       "image": "https://raw.githubusercontent.com/solidjs/solid/main/assets/logo.png"
     },
     {
@@ -66,7 +66,7 @@
       "link": "https://nextjs.org",
       "name": "Next.js",
       "desc": "The React Framework for the Web",
-      "weight": 141744,
+      "weight": 141883,
       "image": "https://avatars.githubusercontent.com/u/14985020?v=4"
     },
     {
@@ -77,7 +77,7 @@
       "link": "https://nuxt.com",
       "name": "Nuxt",
       "desc": "The Intuitive Vue Framework",
-      "weight": 60755,
+      "weight": 60767,
       "image": "https://raw.githubusercontent.com/nuxt/nuxt/main/.github/logo.svg"
     },
     {
@@ -88,7 +88,7 @@
       "link": "https://kit.svelte.dev",
       "name": "SvelteKit",
       "desc": "Web development, streamlined",
-      "weight": 20737,
+      "weight": 20749,
       "image": "https://avatars.githubusercontent.com/u/23617963?v=4"
     },
     {
@@ -99,7 +99,7 @@
       "link": "https://remix.run",
       "name": "Remix",
       "desc": "Build better websites with React",
-      "weight": 33293,
+      "weight": 33312,
       "image": "https://avatars.githubusercontent.com/u/64235328?v=4"
     },
     {
@@ -110,7 +110,7 @@
       "link": "https://astro.build",
       "name": "Astro",
       "desc": "The web framework for content-driven websites",
-      "weight": 61721,
+      "weight": 61885,
       "image": "https://avatars.githubusercontent.com/u/44914786?v=4"
     },
     {
@@ -121,7 +121,7 @@
       "link": "https://vitejs.dev",
       "name": "Vite",
       "desc": "Next generation frontend tooling",
-      "weight": 82332,
+      "weight": 82421,
       "image": "https://avatars.githubusercontent.com/u/65625612?v=4"
     },
     {
@@ -132,7 +132,7 @@
       "link": "https://webpack.js.org",
       "name": "Webpack",
       "desc": "A bundler for javascript and friends",
-      "weight": 65989,
+      "weight": 65971,
       "image": "https://avatars.githubusercontent.com/u/2105791?v=4"
     },
     {
@@ -143,7 +143,7 @@
       "link": "https://esbuild.github.io",
       "name": "esbuild",
       "desc": "An extremely fast bundler for the web",
-      "weight": 40018
+      "weight": 40007
     },
     {
       "id": "rollup/rollup",
@@ -153,7 +153,7 @@
       "link": "https://rollupjs.org",
       "name": "Rollup",
       "desc": "Next-generation ES module bundler",
-      "weight": 26305,
+      "weight": 26306,
       "image": "https://avatars.githubusercontent.com/u/12554859?v=4"
     },
     {
@@ -164,7 +164,7 @@
       "link": "https://parceljs.org",
       "name": "Parcel",
       "desc": "The zero configuration build tool for the web",
-      "weight": 44025,
+      "weight": 44020,
       "image": "https://avatars.githubusercontent.com/u/32607881?v=4"
     },
     {
@@ -175,7 +175,7 @@
       "link": "https://tailwindcss.com",
       "name": "Tailwind CSS",
       "desc": "A utility-first CSS framework for rapid UI development",
-      "weight": 97220,
+      "weight": 97287,
       "image": "https://avatars.githubusercontent.com/u/67109815?v=4"
     },
     {
@@ -186,7 +186,7 @@
       "link": "https://getbootstrap.com",
       "name": "Bootstrap",
       "desc": "The most popular HTML, CSS, and JS library in the world",
-      "weight": 174585,
+      "weight": 174622,
       "image": "https://avatars.githubusercontent.com/u/2918581?v=4"
     },
     {
@@ -197,7 +197,7 @@
       "link": "https://bulma.io",
       "name": "Bulma",
       "desc": "Modern CSS framework based on Flexbox",
-      "weight": 50058
+      "weight": 50053
     },
     {
       "id": "styled-components/styled-components",
@@ -207,7 +207,7 @@
       "link": "https://styled-components.com",
       "name": "styled-components",
       "desc": "Visual primitives for the component age",
-      "weight": 41128,
+      "weight": 41123,
       "image": "https://avatars.githubusercontent.com/u/20658825?v=4"
     },
     {
@@ -218,7 +218,7 @@
       "link": "https://sass-lang.com",
       "name": "Sass",
       "desc": "Dart implementation of Sass, a CSS preprocessor",
-      "weight": 4213,
+      "weight": 4215,
       "image": "https://avatars.githubusercontent.com/u/317889?v=4"
     },
     {
@@ -229,7 +229,7 @@
       "link": "https://expressjs.com",
       "name": "Express",
       "desc": "Fast, unopinionated, minimalist web framework for Node.js",
-      "weight": 69357,
+      "weight": 69382,
       "image": "https://avatars.githubusercontent.com/u/5658226?v=4"
     },
     {
@@ -240,7 +240,7 @@
       "link": "https://nestjs.com",
       "name": "NestJS",
       "desc": "A progressive Node.js framework for building efficient server-side applications",
-      "weight": 76371,
+      "weight": 76406,
       "image": "https://avatars.githubusercontent.com/u/28507035?v=4"
     },
     {
@@ -251,7 +251,7 @@
       "link": "https://fastify.dev",
       "name": "Fastify",
       "desc": "Fast and low overhead web framework, for Node.js",
-      "weight": 36977,
+      "weight": 37012,
       "image": "https://avatars.githubusercontent.com/u/24939410?v=4"
     },
     {
@@ -262,7 +262,7 @@
       "link": "https://www.djangoproject.com",
       "name": "Django",
       "desc": "The Web framework for perfectionists with deadlines",
-      "weight": 88421,
+      "weight": 88490,
       "image": "https://avatars.githubusercontent.com/u/27804?v=4"
     },
     {
@@ -273,7 +273,7 @@
       "link": "https://rubyonrails.org",
       "name": "Ruby on Rails",
       "desc": "A web-application framework for Ruby",
-      "weight": 58688,
+      "weight": 58698,
       "image": "https://avatars.githubusercontent.com/u/4223?v=4"
     },
     {
@@ -284,7 +284,7 @@
       "link": "https://redux.js.org",
       "name": "Redux",
       "desc": "A predictable state container for JavaScript apps",
-      "weight": 61522,
+      "weight": 61507,
       "image": "https://avatars.githubusercontent.com/u/13142323?v=4"
     },
     {
@@ -295,7 +295,7 @@
       "link": "https://mobx.js.org",
       "name": "MobX",
       "desc": "Simple, scalable state management",
-      "weight": 28201,
+      "weight": 28203,
       "image": "https://avatars.githubusercontent.com/u/17475736?v=4"
     },
     {
@@ -306,7 +306,7 @@
       "link": "https://zustand-demo.pmnd.rs",
       "name": "Zustand",
       "desc": "A small, fast, and scalable bearbones state-management solution",
-      "weight": 58558,
+      "weight": 58587,
       "image": "https://avatars.githubusercontent.com/u/45790596?v=4"
     },
     {
@@ -317,7 +317,7 @@
       "link": "https://pinia.vuejs.org",
       "name": "Pinia",
       "desc": "The intuitive store for Vue.js",
-      "weight": 14694,
+      "weight": 14701,
       "image": "https://avatars.githubusercontent.com/u/6128107?v=4"
     },
     {
@@ -328,7 +328,7 @@
       "link": "https://stately.ai/docs/xstate",
       "name": "XState",
       "desc": "State machines and statecharts for the modern web",
-      "weight": 30003,
+      "weight": 30036,
       "image": "https://avatars.githubusercontent.com/u/61783956?v=4"
     },
     {
@@ -339,7 +339,7 @@
       "link": "https://jestjs.io",
       "name": "Jest",
       "desc": "Delightful JavaScript testing",
-      "weight": 45472,
+      "weight": 45469,
       "image": "https://avatars.githubusercontent.com/u/103283236?v=4"
     },
     {
@@ -350,7 +350,7 @@
       "link": "https://www.cypress.io",
       "name": "Cypress",
       "desc": "Fast, easy and reliable testing for anything that runs in a browser",
-      "weight": 50943,
+      "weight": 50979,
       "image": "https://avatars.githubusercontent.com/u/8908513?v=4"
     },
     {
@@ -361,7 +361,7 @@
       "link": "https://playwright.dev",
       "name": "Playwright",
       "desc": "Reliable end-to-end testing for modern web apps",
-      "weight": 94417,
+      "weight": 94796,
       "image": "https://avatars.githubusercontent.com/u/6154722?v=4"
     },
     {
@@ -372,7 +372,7 @@
       "link": "https://vitest.dev",
       "name": "Vitest",
       "desc": "A blazing fast unit test framework powered by Vite",
-      "weight": 16941,
+      "weight": 16982,
       "image": "https://avatars.githubusercontent.com/u/95747107?v=4"
     },
     {
@@ -383,7 +383,7 @@
       "link": "https://mochajs.org",
       "name": "Mocha",
       "desc": "Simple, flexible, fun JavaScript test framework",
-      "weight": 22904,
+      "weight": 22902,
       "image": "https://avatars.githubusercontent.com/u/8770005?v=4"
     },
     {
@@ -394,7 +394,7 @@
       "link": "https://www.gatsbyjs.com",
       "name": "Gatsby",
       "desc": "Build blazing fast, modern apps and websites with React",
-      "weight": 55941,
+      "weight": 55943,
       "image": "https://avatars.githubusercontent.com/u/12551863?v=4"
     },
     {
@@ -405,7 +405,7 @@
       "link": "https://gohugo.io",
       "name": "Hugo",
       "desc": "The world's fastest framework for building websites",
-      "weight": 89423,
+      "weight": 89459,
       "image": "https://avatars.githubusercontent.com/u/29385237?v=4"
     },
     {
@@ -416,7 +416,7 @@
       "link": "https://jekyllrb.com",
       "name": "Jekyll",
       "desc": "Transform your plain text into static websites and blogs",
-      "weight": 51636,
+      "weight": 51639,
       "image": "https://avatars.githubusercontent.com/u/3083652?v=4"
     },
     {
@@ -427,7 +427,7 @@
       "link": "https://www.11ty.dev",
       "name": "Eleventy",
       "desc": "A simpler static site generator",
-      "weight": 19843,
+      "weight": 19857,
       "image": "https://avatars.githubusercontent.com/u/35147177?v=4"
     },
     {
@@ -438,7 +438,7 @@
       "link": "https://docusaurus.io",
       "name": "Docusaurus",
       "desc": "Easy to maintain open source documentation websites",
-      "weight": 65901,
+      "weight": 66014,
       "image": "https://avatars.githubusercontent.com/u/69631?v=4"
     },
     {
@@ -449,7 +449,7 @@
       "link": "https://graphql.org",
       "name": "GraphQL.js",
       "desc": "A reference implementation of GraphQL for JavaScript",
-      "weight": 20344,
+      "weight": 20342,
       "image": "https://avatars.githubusercontent.com/u/12972006?v=4"
     },
     {
@@ -460,7 +460,7 @@
       "link": "https://www.apollographql.com/docs/react/",
       "name": "Apollo Client",
       "desc": "A fully-featured caching GraphQL client",
-      "weight": 19812,
+      "weight": 19808,
       "image": "https://avatars.githubusercontent.com/u/17189275?v=4"
     },
     {
@@ -471,7 +471,7 @@
       "link": "https://trpc.io",
       "name": "tRPC",
       "desc": "End-to-end typesafe APIs made easy",
-      "weight": 40515,
+      "weight": 40526,
       "image": "https://avatars.githubusercontent.com/u/78011399?v=4"
     },
     {
@@ -482,7 +482,7 @@
       "link": "https://www.prisma.io",
       "name": "Prisma",
       "desc": "Next-generation Node.js and TypeScript ORM",
-      "weight": 47564,
+      "weight": 47574,
       "image": "https://avatars.githubusercontent.com/u/17219288?v=4"
     },
     {
@@ -493,7 +493,7 @@
       "link": "https://axios-http.com",
       "name": "Axios",
       "desc": "Promise based HTTP client for the browser and node.js",
-      "weight": 109233,
+      "weight": 109196,
       "image": "https://avatars.githubusercontent.com/u/32372333?v=4"
     },
     {
@@ -504,7 +504,7 @@
       "link": "https://mui.com",
       "name": "Material UI",
       "desc": "React components that implement Google's Material Design",
-      "weight": 98751,
+      "weight": 98872,
       "image": "https://avatars.githubusercontent.com/u/33663932?v=4"
     },
     {
@@ -515,7 +515,7 @@
       "link": "https://ant.design",
       "name": "Ant Design",
       "desc": "An enterprise-class UI design language and React UI library",
-      "weight": 99053,
+      "weight": 99126,
       "image": "https://avatars.githubusercontent.com/u/12101536?v=4"
     },
     {
@@ -526,7 +526,7 @@
       "link": "https://chakra-ui.com",
       "name": "Chakra UI",
       "desc": "Simple, modular and accessible component library for React",
-      "weight": 40571,
+      "weight": 40584,
       "image": "https://avatars.githubusercontent.com/u/54212428?v=4"
     },
     {
@@ -537,7 +537,7 @@
       "link": "https://ui.shadcn.com",
       "name": "shadcn/ui",
       "desc": "Beautifully designed components you can copy and paste into your apps",
-      "weight": 121187,
+      "weight": 121697,
       "image": "https://avatars.githubusercontent.com/u/139895814?v=4"
     },
     {
@@ -548,8 +548,63 @@
       "link": "https://www.radix-ui.com",
       "name": "Radix UI",
       "desc": "An open-source UI component library for building accessible design systems",
-      "weight": 19159,
+      "weight": 19188,
       "image": "https://avatars.githubusercontent.com/u/75042455?v=4"
+    },
+    {
+      "id": "fastapi/fastapi",
+      "path": [
+        "Backend Frameworks"
+      ],
+      "link": "https://fastapi.tiangolo.com/",
+      "name": "FastAPI",
+      "desc": "Modern, high-performance Python web framework for building APIs",
+      "weight": 101722,
+      "image": "https://avatars.githubusercontent.com/u/156354296?v=4"
+    },
+    {
+      "id": "laravel/laravel",
+      "path": [
+        "Backend Frameworks"
+      ],
+      "link": "https://laravel.com",
+      "name": "Laravel",
+      "desc": "PHP web application framework with expressive, elegant syntax",
+      "weight": 84831,
+      "image": "https://avatars.githubusercontent.com/u/958072?v=4"
+    },
+    {
+      "id": "pallets/flask",
+      "path": [
+        "Backend Frameworks"
+      ],
+      "link": "https://flask.palletsprojects.com",
+      "name": "Flask",
+      "desc": "Lightweight WSGI web application framework for Python",
+      "weight": 72142,
+      "image": "https://avatars.githubusercontent.com/u/16748505?v=4"
+    },
+    {
+      "id": "eslint/eslint",
+      "path": [
+        "Developer Tooling"
+      ],
+      "link": "https://eslint.org",
+      "name": "ESLint",
+      "desc": "Pluggable linter for finding and fixing problems in JavaScript code",
+      "weight": 27463,
+      "image": "https://avatars.githubusercontent.com/u/6019716?v=4"
+    },
+    {
+      "id": "storybookjs/storybook",
+      "path": [
+        "Developer Tooling"
+      ],
+      "link": "https://storybook.js.org",
+      "name": "Storybook",
+      "desc": "Workshop for building, documenting, and testing UI components in isolation",
+      "weight": 90880,
+      "image": "https://avatars.githubusercontent.com/u/22632046?v=4"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Cross-referenced [sindresorhus/awesome](https://github.com/sindresorhus/awesome) against the existing maps and filled notable gaps, then added two new domains covering territory the meta-list surfaced but this repo didn't cover yet.

**Added to existing maps** (weights/logos fetched live via `scripts/enrich-domain.mjs`):
- Web Dev (+5): FastAPI, Laravel, Flask, ESLint, Storybook — new "Developer Tooling" category
- DevOps & Infra (+4): NGINX, Traefik, Backstage, OpenTelemetry Collector — new "Reverse Proxy & Load Balancing" and "Developer Portals & Platform Engineering" categories
- Security (+4): Wireshark, YARA, osquery, CrowdSec
- Databases (+1): Neon

**New domains:**
- `data/automation.json` — Automation & No-Code (48 projects, 8 categories: Workflow Automation, Job Orchestration & Scheduling, RPA & Browser Automation, Web Scraping & Data Extraction, Low-Code & No-Code Builders, Business Process/ERP/Finance, Data & Notification Integration, Marketing & Email Automation). Headlined by n8n.
- `data/smart-home.json` — IoT & Smart Home (41 projects, 8 categories: Home Automation Platforms, Device Protocols & Telemetry, Automation Rules & Dashboards, Embedded Firmware & Dev Platforms, Voice Assistants, Robotics & Autonomous Systems, Camera & Security Automation, 3D Printing & Fabrication). Headlined by Home Assistant.

README's map table updated with the two new rows and corrected project counts for the four maps that grew.

## Test plan
- [x] `npm test` — 166/166 passing
- [x] `npm run generate` — builds all 9 domains cleanly
- [x] Spot-checked rendered `dist/` output for new categories/projects in web-dev, devops-infra, security, databases, automation, smart-home

Note: the two new maps won't show anything in Rising mode until the first scheduled `snapshot-history` run captures a baseline — same as any brand-new domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)