### PR TITLE
fix: add shortName for Automation and IoT/Smart Home domains

### DIFF
--- a/data/automation.json
+++ b/data/automation.json
@@ -1,6 +1,7 @@
 {
   "slug": "automation",
   "name": "Best Automation & No-Code Open Source Projects",
+  "shortName": "Automation",
   "description": "Workflow automation, RPA, no-code app builders, and business process tooling.",
   "projects": [
     {

--- a/data/smart-home.json
+++ b/data/smart-home.json
@@ -1,6 +1,7 @@
 {
   "slug": "smart-home",
   "name": "Best IoT & Smart Home Open Source Projects",
+  "shortName": "IoT & Smart Home",
   "description": "Home automation platforms, embedded firmware, robotics, and device protocols.",
   "projects": [
     {


### PR DESCRIPTION
Follow-up to #16 — the Automation and IoT/Smart Home domains (added in #15) landed before the `shortName` field existed, so they were falling back to their long SEO titles in the Rising pills and quick-filter chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)