### PR TITLE
Link leaderboard rows to internal project pages instead of external homepages

### DIFF
--- a/product.md
+++ b/product.md
@@ -10,7 +10,7 @@ Added from a user-perspective walkthrough of the live site and source on
 2026-08-28, focused on where visitors get stuck or leave earlier than they
 need to.
 
-- [ ] Point leaderboard rows at the internal project page instead of the
+- [x] Point leaderboard rows at the internal project page instead of the
       project's external homepage. `renderRisingRow` in
       `scripts/render-page.mjs` links each row's name to `entry.link`
       (sourced from `project.link`) — on the homepage teaser and the full

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -110,7 +110,7 @@ export function renderDomainPage(
   const footer = embed ? "" : renderSiteFooter();
   const teaserSection = embed
     ? ""
-    : renderRisingTeaser(teaser, { heading: "Rising this week", href: `${basePath}/rising/#${domain.slug}`, showDomain: false });
+    : renderRisingTeaser(teaser, { heading: "Rising this week", href: `${basePath}/rising/#${domain.slug}`, showDomain: false, basePath });
   // Omitted from embeds along with the rest of the chrome — an embedded map is
   // a visualization, not a page.
   const categorySection = embed ? "" : renderCategoryMomentum(categoryGrowth, { windowDays: momentumWindowDays });
@@ -323,7 +323,7 @@ export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", baseP
         </a>`;
     })
     .join("");
-  const teaserSection = renderRisingTeaser(teaser, { heading: "Rising this week", href: `${basePath}/rising/`, showDomain: true });
+  const teaserSection = renderRisingTeaser(teaser, { heading: "Rising this week", href: `${basePath}/rising/`, showDomain: true, basePath });
   const websiteJsonLd = renderJsonLd(
     buildWebsiteJsonLd({
       name: "awesomemap",
@@ -366,8 +366,18 @@ export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", baseP
   });
 }
 
-/** Formats one leaderboard entry (as returned by leaderboard.mjs's computeLeaderboard) as a row. `showDomain` controls whether the cross-domain tag is shown — true for the global list, false for a single domain's own list. */
-function renderRisingRow(entry, { showDomain }) {
+/**
+ * Formats one leaderboard entry (as returned by leaderboard.mjs's
+ * computeLeaderboard) as a row. `showDomain` controls whether the
+ * cross-domain tag is shown — true for the global list, false for a single
+ * domain's own list. The name links to the project's own internal page
+ * (`/projects/<id>/`, prefixed by `basePath`) rather than straight to
+ * `entry.link` (the external homepage) — that page is what shows the
+ * description, star-history sparkline, domain rank, and tags before
+ * sending visitors onward. `entry.link` is used only as a fallback for the
+ * (currently theoretical) case of an entry with no project id.
+ */
+function renderRisingRow(entry, { showDomain, basePath }) {
   const arrowSymbol = entry.rankDelta > 0 ? "▲" : entry.rankDelta < 0 ? "▼" : "–";
   const arrowClass = entry.rankDelta > 0 ? "rising-row-up" : entry.rankDelta < 0 ? "rising-row-down" : "rising-row-flat";
   const movedBy = Math.abs(entry.rankDelta);
@@ -379,12 +389,13 @@ function renderRisingRow(entry, { showDomain }) {
     ? `<span class="rising-row-domain" title="${escapeHtml(entry.domain)}">${escapeHtml(domainShort)}</span>`
     : "";
   const repoId = entry.id ? `<span class="rising-row-repo">${escapeHtml(entry.id)}</span>` : "";
+  const projectHref = entry.id ? `${basePath}/projects/${entry.id}/` : (entry.link ?? "#");
   return `
     <li class="rising-row" data-domain="${escapeHtml(entry.domainSlug ?? "")}">
       <span class="rising-row-rank">${entry.rank}</span>
       ${icon}
       <span class="rising-row-title">
-        <a class="rising-row-name" href="${escapeHtml(entry.link ?? "#")}">${escapeHtml(entry.name)}</a>
+        <a class="rising-row-name" href="${escapeHtml(projectHref)}">${escapeHtml(entry.name)}</a>
         ${repoId}
       </span>
       ${domainTag}
@@ -394,11 +405,11 @@ function renderRisingRow(entry, { showDomain }) {
 }
 
 /** Renders a leaderboard's rows, or a not-ready placeholder when `entries` is empty (e.g. a domain too new for this window). Shared with the teaser sections added in Task 4. */
-function renderRisingRows(entries, { showDomain }) {
+function renderRisingRows(entries, { showDomain, basePath }) {
   if (entries.length === 0) {
     return `<p class="rising-empty">Not enough star-history yet for this window.</p>`;
   }
-  return `<ol class="rising-rows-list">${entries.map((entry) => renderRisingRow(entry, { showDomain })).join("")}</ol>`;
+  return `<ol class="rising-rows-list">${entries.map((entry) => renderRisingRow(entry, { showDomain, basePath })).join("")}</ol>`;
 }
 
 /**
@@ -406,11 +417,11 @@ function renderRisingRows(entries, { showDomain }) {
  * window) linking to the full leaderboard — used on the landing page
  * (global) and each domain page (that domain's own list).
  */
-function renderRisingTeaser(entries, { heading, href, showDomain }) {
+function renderRisingTeaser(entries, { heading, href, showDomain, basePath }) {
   return `
     <section class="rising-teaser">
       <h2 class="rising-teaser-heading">${escapeHtml(heading)}</h2>
-      ${renderRisingRows(entries, { showDomain })}
+      ${renderRisingRows(entries, { showDomain, basePath })}
       <a class="rising-teaser-link" href="${escapeHtml(href)}">See full leaderboard →</a>
     </section>`;
 }
@@ -423,20 +434,20 @@ function renderRisingTeaser(entries, { heading, href, showDomain }) {
  * `{ [windowDays]: { [scopeKey]: entries[] } }`; `scopeKey` selects which
  * leaderboard within each window this section shows.
  */
-function renderRisingWindowVariants(leaderboardsByWindow, scopeKey, { showDomain }) {
+function renderRisingWindowVariants(leaderboardsByWindow, scopeKey, { showDomain, basePath }) {
   return RISING_WINDOWS_DAYS.map((windowDays, index) => {
     const entries = leaderboardsByWindow[windowDays]?.[scopeKey] ?? [];
     const hiddenAttr = index === 0 ? "" : " hidden";
-    return `<div class="rising-rows" data-window="${windowDays}"${hiddenAttr}>${renderRisingRows(entries, { showDomain })}</div>`;
+    return `<div class="rising-rows" data-window="${windowDays}"${hiddenAttr}>${renderRisingRows(entries, { showDomain, basePath })}</div>`;
   }).join("");
 }
 
 /** One full leaderboard section (heading + all three window variants), anchorable by `id`. `hidden` starts the whole section — not just individual rows — collapsed, for sections the domain filter hasn't selected yet. */
-function renderRisingSection({ id, heading, leaderboardsByWindow, scopeKey, showDomain, hidden = false }) {
+function renderRisingSection({ id, heading, leaderboardsByWindow, scopeKey, showDomain, basePath, hidden = false }) {
   return `
     <section class="rising-section" id="${escapeHtml(id)}"${hidden ? " hidden" : ""}>
       <h2 class="rising-section-heading">${escapeHtml(heading)}</h2>
-      ${renderRisingWindowVariants(leaderboardsByWindow, scopeKey, { showDomain })}
+      ${renderRisingWindowVariants(leaderboardsByWindow, scopeKey, { showDomain, basePath })}
     </section>`;
 }
 
@@ -461,6 +472,7 @@ export function renderRisingPage(domains, leaderboardsByWindow, { defaultOgImage
     leaderboardsByWindow,
     scopeKey: "global",
     showDomain: true,
+    basePath,
   });
 
   const domainSections = domains
@@ -471,6 +483,7 @@ export function renderRisingPage(domains, leaderboardsByWindow, { defaultOgImage
         leaderboardsByWindow,
         scopeKey: domain.slug,
         showDomain: false,
+        basePath,
         hidden: true,
       })
     )

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -202,9 +202,26 @@ test("renderRisingPage renders a row per leaderboard entry, with rank, arrow, an
   };
   const html = renderRisingPage(domains, leaderboardsByWindow, { defaultOgImage: "/og-default.png" });
   assert.match(html, /<span class="rising-row-rank">1<\/span>/);
-  assert.match(html, /<a class="rising-row-name" href="https:\/\/a\.example">Project A<\/a>/);
+  assert.match(html, /<a class="rising-row-name" href="\/projects\/a\/a\/">Project A<\/a>/);
   assert.match(html, /rising-row-up">▲1<\/span>/);
   assert.match(html, /\+40 \(\+40\.0%\)/);
+});
+
+test("renderRisingPage's row links point at the project's own internal page (prefixed by BASE_PATH), not its external homepage — so visitors see the description, sparkline, and tags before leaving the site", () => {
+  const domains = [{ slug: "data-science", name: "Data Science" }];
+  const leaderboardsByWindow = {
+    7: {
+      global: [
+        { rank: 1, id: "a/a", name: "Project A", link: "https://a.example", domain: "Data Science", starDelta: 40, percentDelta: 40, rankDelta: 1 },
+      ],
+      "data-science": [],
+    },
+    30: { global: [], "data-science": [] },
+    90: { global: [], "data-science": [] },
+  };
+  const html = renderRisingPage(domains, leaderboardsByWindow, { defaultOgImage: "/og-default.png", basePath: "/techmap" });
+  assert.match(html, /<a class="rising-row-name" href="\/techmap\/projects\/a\/a\/">Project A<\/a>/);
+  assert.doesNotMatch(html, /href="https:\/\/a\.example"/);
 });
 
 test("renderRisingPage's rows show the repo id and the domain's short name, and carry the domain's slug for filtering", () => {
@@ -334,6 +351,13 @@ test("renderDomainPage renders a teaser section below the map, linking to that d
   assert.ok(html.indexOf('id="app"') < html.indexOf('class="rising-teaser"'));
 });
 
+test("renderDomainPage's teaser row links at the project's internal page, prefixed by BASE_PATH", () => {
+  const domain = { slug: "data-science", name: "Data Science", description: "desc" };
+  const teaser = [{ rank: 1, id: "a/a", name: "Project A", link: "https://a.example", domain: "Data Science", starDelta: 40, percentDelta: 40, rankDelta: 0 }];
+  const html = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png", basePath: "/techmap", teaser });
+  assert.match(html, /<a class="rising-row-name" href="\/techmap\/projects\/a\/a\/">Project A<\/a>/);
+});
+
 test("renderDomainPage's embed variant has no teaser section", () => {
   const domain = { slug: "data-science", name: "Data Science", description: "desc" };
   const teaser = [{ rank: 1, id: "a/a", name: "Project A", link: "https://a.example", domain: "Data Science", starDelta: 40, percentDelta: 40, rankDelta: 0 }];
@@ -347,6 +371,16 @@ test("renderLandingPage renders a global teaser section between the hero and the
   assert.match(html, /class="rising-teaser-link" href="\/rising\/"/);
   assert.ok(html.indexOf('class="hero"') < html.indexOf('class="rising-teaser"'));
   assert.ok(html.indexOf('class="rising-teaser"') < html.indexOf('class="map-grid"'));
+});
+
+test("renderLandingPage's teaser row links at the project's internal page, prefixed by BASE_PATH", () => {
+  const teaser = [{ rank: 1, id: "a/a", name: "Project A", link: "https://a.example", domain: "Data Science", starDelta: 40, percentDelta: 40, rankDelta: 0 }];
+  const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], {
+    defaultOgImage: "/og-default.png",
+    basePath: "/techmap",
+    teaser,
+  });
+  assert.match(html, /<a class="rising-row-name" href="\/techmap\/projects\/a\/a\/">Project A<\/a>/);
 });
 
 test("renderLandingPage's hero includes a quick-jump link per domain, using its short name", () => {


### PR DESCRIPTION
## Summary
Closes the first item under **Flow & conversion** in `product.md`:

Leaderboard rows (on the homepage/domain-page "Rising this week" teasers and the full `/rising/` page) linked each project's name straight to `entry.link` — its external homepage/GitHub URL — sending visitors off-domain before they ever saw the description, star-history sparkline, domain rank, or tags that live on `/projects/<id>/`.

This change points the row link at that internal project page instead (`${basePath}/projects/${entry.id}/`), letting it be the one that sends people onward to GitHub/homepage.

## Changes
- `renderRisingRow` now builds its `href` from `basePath` + `entry.id` instead of `entry.link`, with `entry.link` kept only as a defensive fallback for the (currently unreachable, per `generate.mjs`'s id validation) case of an entry with no project id.
- `basePath` is threaded through the render chain: `renderRisingRow` → `renderRisingRows` → `renderRisingTeaser` / `renderRisingWindowVariants` → `renderRisingSection`, and all three call sites (`renderDomainPage`, `renderLandingPage`, `renderRisingPage`).
- `product.md` backlog item checked off.

## Testing
- Added/updated tests in `test/render-page.test.js` covering the rising page, and both teaser variants (domain page + landing page), for both `basePath: ""` and a prefixed `basePath`.
- `node --test`: 321/321 passing.
- Reviewed by a subagent code reviewer (Ready to merge: Yes, no Critical/Important issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)