### PR TITLE
Give category boxes a distinct visual affordance

### DIFF
--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -72,6 +72,20 @@ body {
   z-index: 1;
 }
 
+/* A category zooms in on click while a leaf opens the detail panel, and
+   the two otherwise share the same chrome — this corner chevron gives a
+   visual cue for "there's more inside" before the first click. */
+.treemap-category::after {
+  content: "▸";
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 10px;
+  line-height: 1;
+  color: var(--color-accent);
+  pointer-events: none;
+}
+
 .treemap-category {
   background: var(--color-accent-soft);
   align-items: flex-start;

--- a/product.md
+++ b/product.md
@@ -20,13 +20,14 @@ need to.
       `/projects/<id>/` (and in the treemap's detail panel,
       `app/shared/detail-panel.js`). Link the name internally and let that
       page be the one that sends people onward to GitHub/homepage.
-- [ ] Give category and leaf boxes a distinct visual affordance.
+- [x] Give category and leaf boxes a distinct visual affordance.
       `.treemap-category` and `.treemap-leaf` (`app/shared/treemap.css`)
       share the same chrome and both use `cursor: pointer` — a category
       click zooms in, a leaf click opens the detail panel, and nothing
-      distinguishes the two until you click. A corner chevron/folder glyph
-      on categories (or a subtly different border) would remove the
-      guesswork on a visitor's first interaction.
+      distinguishes the two until you click. Fixed with a `▸` corner
+      glyph on `.treemap-category` (via `::after`, colored with
+      `--color-accent` so it follows light/dark mode) to signal
+      "zooms into more" before the first click.
 - [ ] Reflect zoom depth and mode/window in the URL. `zoomTo`/
       `zoomToOthers` in `app/shared/treemap.js` never call
       `history.pushState` — so a zoomed-in view can't be shared or


### PR DESCRIPTION
## Summary
- Adds a small `▸` corner chevron to `.treemap-category` boxes so it's clear before the first click that a category zooms in, distinct from a leaf box (which opens the detail panel).
- Pure CSS: `::after` pseudo-element colored with `--color-accent`, so it automatically tracks light/dark mode.
- Marks the corresponding item done in `product.md`.

## Verification
- `npm test` — all 318 tests pass.
- Visually checked via headless Chromium against a local `npm run generate && serve dist`: chevron renders on category boxes only (not leaves, not peek tiles, not the "N more" others box) in both light and dark mode, and zoom-in/zoom-out still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)