### PR TITLE
Reflect zoom depth and mode/window in the URL

### DIFF
--- a/app/shared/treemap.js
+++ b/app/shared/treemap.js
@@ -62,9 +62,23 @@ const COLLAGE_MAX_ICONS = 4;
  * arguments right after the Popular/Rising mode or window is switched —
  * consumers use it to dismiss any already-open detail panel, since its
  * baked-in growth stats would otherwise go stale against the new mode.
+ *
+ * `initialState` (`{ mode, window, idPath }`, e.g. from `zoom-url.js`'s
+ * `parseZoomState`), if given, seeds the mode/window/zoom depth the
+ * treemap mounts into — before the first render, so there's no flash of
+ * the root view. `onNavigate(state, { replace })`, if given, is called
+ * with the same shape right after a real (non-Others) zoom or a mode/window
+ * switch, so a caller can mirror it into the URL; `replace` is `true` for
+ * a mode/window switch (in place — not a step a back button should undo)
+ * and `false` for a zoom (its own history entry). Zooming into a synthetic
+ * "Others" box deliberately does *not* fire `onNavigate` — see
+ * `zoomToOthers`. The returned handle's `applyState(state)` is the
+ * inverse of `onNavigate`: it restores the treemap to match a state
+ * (e.g. from a `popstate` event) without re-firing `onNavigate` itself,
+ * so callers can round-trip state through the URL without looping.
  */
-export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
-  let sizeMode = "popular"; // "popular" | "rising"
+export function mountTreemap(container, mapData, onLeafClick, onModeChange, { initialState, onNavigate } = {}) {
+  let sizeMode = initialState?.mode ?? "popular"; // "popular" | "rising"
   // The shortest window, matching the one every server-rendered surface leads
   // with (generate.mjs's MOMENTUM_WINDOW_DAYS / TEASER_WINDOW_DAYS, both
   // RISING_WINDOWS_DAYS[0]), so a visitor who arrives from a landing card or a
@@ -72,10 +86,13 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
   // It's also the only window that degrades gracefully as history accrues: a
   // longer default renders every box as insufficient-history until the
   // snapshot archive is deep enough to fill it.
-  let risingWindow = RISING_WINDOWS_DAYS[0];
+  let risingWindow = initialState?.window ?? RISING_WINDOWS_DAYS[0];
   let root = buildHierarchy(mapData, activeSizeKey());
-  let focusNode = root;
-  let focusIdPath = [root.data.id];
+  // `findNodeByIdPath` walks as far into `initialState.idPath` as the
+  // hierarchy actually resolves, falling back the same way a mode switch
+  // does for a stale/foreign id — see its own doc comment.
+  let focusNode = initialState?.idPath ? findNodeByIdPath(root, initialState.idPath) : root;
+  let focusIdPath = focusNode.ancestors().reverse().map((ancestor) => ancestor.data.id);
 
   let stageWidth;
   let stageHeight;
@@ -126,11 +143,44 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
     return sizeMode === "popular" ? "popular" : `rising${risingWindow}`;
   }
 
+  /** The `{ mode, window, idPath }` shape `onNavigate`/`applyState` share with `zoom-url.js`. */
+  function currentState() {
+    return { mode: sizeMode, window: risingWindow, idPath: focusIdPath };
+  }
+
   function setSizeMode(nextMode, nextWindow) {
     sizeMode = nextMode;
     risingWindow = nextWindow;
     root = buildHierarchy(mapData, activeSizeKey());
     focusNode = findNodeByIdPath(root, focusIdPath);
+    // Re-derived from the (possibly bailed-out-to-a-real-ancestor) focusNode
+    // rather than left as-is: if Others didn't survive the switch, the old
+    // focusIdPath would otherwise still describe the no-longer-current
+    // synthetic node.
+    focusIdPath = focusNode.ancestors().reverse().map((ancestor) => ancestor.data.id);
+    renderModeBar();
+    renderBreadcrumb();
+    renderLevel();
+    onModeChange?.();
+    onNavigate?.(currentState(), { replace: true });
+  }
+
+  /**
+   * Restores the treemap to `state` (`{ mode, window, idPath }`) without
+   * firing `onNavigate` — the inverse direction from `setSizeMode`/`zoomTo`,
+   * for a caller re-driving the treemap *from* an already-decided target
+   * (e.g. a `popstate` event) rather than reporting a change it made itself.
+   * Also fires `onModeChange` unconditionally: any already-open detail
+   * panel may no longer even correspond to a visible leaf once focus has
+   * jumped elsewhere, so it's dismissed the same as an in-treemap mode
+   * switch would.
+   */
+  function applyState(state) {
+    sizeMode = state.mode;
+    risingWindow = state.window;
+    root = buildHierarchy(mapData, activeSizeKey());
+    focusNode = findNodeByIdPath(root, state.idPath);
+    focusIdPath = focusNode.ancestors().reverse().map((ancestor) => ancestor.data.id);
     renderModeBar();
     renderBreadcrumb();
     renderLevel();
@@ -168,11 +218,17 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
     return current;
   }
 
-  function zoomTo(node) {
+  /** Sets focus to `node` and re-renders, without touching navigation state. */
+  function focusOn(node) {
     focusNode = node;
     focusIdPath = node.ancestors().reverse().map((ancestor) => ancestor.data.id);
     renderBreadcrumb();
     renderLevel();
+  }
+
+  function zoomTo(node) {
+    focusOn(node);
+    onNavigate?.(currentState(), { replace: false });
   }
 
   /**
@@ -183,6 +239,12 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
    * `ancestors()` (breadcrumb, `focusIdPath`) walks back through the real
    * tree exactly like zooming into an ordinary category would.
    *
+   * Deliberately calls `focusOn` rather than `zoomTo`: an Others bucket's
+   * membership isn't stable across a mode/window switch (see
+   * `findNodeByIdPath`), so it's not a meaningful thing to bookmark or
+   * share — this view updates on-page like any other zoom, it just never
+   * reaches `onNavigate`/the URL.
+   *
    * Note: switching Popular/Rising mode (or window) while focus is on this
    * synthetic node will not restore it — see `findNodeByIdPath` for why
    * that's the intended fallback, not a bug.
@@ -190,7 +252,7 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
   function zoomToOthers(othersData, parentNode) {
     const syntheticNode = buildHierarchy(othersData, activeSizeKey());
     syntheticNode.parent = parentNode;
-    zoomTo(syntheticNode);
+    focusOn(syntheticNode);
   }
 
   function renderModeBar() {
@@ -497,7 +559,7 @@ export function mountTreemap(container, mapData, onLeafClick, onModeChange) {
   });
   resizeObserver.observe(container);
 
-  return { zoomTo, root };
+  return { zoomTo, root, applyState };
 }
 
 /**

--- a/app/shared/zoom-url.js
+++ b/app/shared/zoom-url.js
@@ -1,0 +1,69 @@
+/**
+ * Pure encode/decode helpers for reflecting a treemap's zoom depth and
+ * Popular/Rising mode+window in a page's query string, so a zoomed-in view
+ * can be shared, bookmarked, and reloaded, and so the browser back button
+ * has real per-zoom-level history entries to step through. Framework- and
+ * DOM-free (no `window`/`location` access) so it's usable both from
+ * `treemap.js`'s browser code and from `node --test`; `treemap.js` owns
+ * turning the parsed `idPath` into an actual focus node (it already has
+ * the fallback logic for an id that no longer resolves, via
+ * `findNodeByIdPath`) and owns all `history`/`location` calls.
+ */
+
+/**
+ * Parses `searchParams` into `{ mode, window, idPath }`. Anything missing
+ * or invalid (an unrecognized `mode`, a `window` outside `validWindows`)
+ * falls back to the root/Popular/`validWindows[0]` default, so a stale or
+ * hand-edited query string still lands somewhere sane rather than failing
+ * to load. `idPath` is root-first, matching the shape `node.ancestors()`
+ * already produces in `treemap.js` — `rootId` is prepended rather than
+ * read from the URL, since a domain page always knows its own root from
+ * context and never needs to spell it out in the query string.
+ */
+export function parseZoomState(searchParams, { rootId, validWindows }) {
+  const mode = searchParams.get("mode") === "rising" ? "rising" : "popular";
+
+  const requestedWindow = Number(searchParams.get("window"));
+  const window = validWindows.includes(requestedWindow) ? requestedWindow : validWindows[0];
+
+  const idPath = [rootId, ...searchParams.getAll("path")];
+
+  return { mode, window, idPath };
+}
+
+/**
+ * Inverse of `parseZoomState`: builds a query string (including its
+ * leading `?`, or `""` for the bare default) reflecting `state`. Omits
+ * anything already at its default so a fresh, un-zoomed Popular view keeps
+ * the domain page's plain URL. `window` is only ever written while
+ * `mode` is `"rising"` — a Popular-mode `window` carried over from an
+ * earlier Rising visit isn't meaningful until Rising is active again, and
+ * parsing back in without it already lands on `validWindows[0]`, the same
+ * default a first-time switch to Rising gets.
+ *
+ * Each path segment gets its own repeated `path=` entry rather than a
+ * single delimiter-joined value: category ids are free-form names (a
+ * project's own id is `owner/repo`, and a category as ordinary as "CI/CD"
+ * is entirely plausible), and `URLSearchParams` fully percent-decodes a
+ * value before handing it back — a literal `/` inside one segment and a
+ * `/` meant as a separator between segments would become indistinguishable
+ * on the way back out. Repeated params sidestep that: each entry is
+ * encoded and decoded exactly once, whatever it contains.
+ */
+export function formatZoomState({ mode, window, idPath }, { rootId, validWindows }) {
+  const params = new URLSearchParams();
+
+  for (const segment of idPath.slice(1)) {
+    params.append("path", segment); // idPath[0] is always rootId; never written.
+  }
+
+  if (mode === "rising") {
+    params.set("mode", "rising");
+    if (window !== validWindows[0]) {
+      params.set("window", String(window));
+    }
+  }
+
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}

--- a/product.md
+++ b/product.md
@@ -127,11 +127,6 @@ need to.
       reached via search or a shared link has no equivalent, just the mode
       bar itself. A small "?" affordance near the mode bar would cover
       that entry path.
-- [ ] Reflect zoom depth and mode/window in the URL. `zoomTo`/
-      `zoomToOthers` in `app/shared/treemap.js` never call
-      `history.pushState` — so a zoomed-in view can't be shared or
-      bookmarked, and on mobile the back button/gesture exits the page
-      instead of stepping back one zoom level the way users expect.
 - [ ] Add a backdrop-click / Escape dismissal to the detail panel.
       `createDetailPanel` (`app/shared/detail-panel.js`) only wires close
       to the `×` button and to a mode switch — on narrow viewports the
@@ -165,6 +160,19 @@ need to.
 
 ## Shipped
 
+- [x] Reflect zoom depth and mode/window in the URL. `zoomTo`/
+      `zoomToOthers` in `app/shared/treemap.js` never call
+      `history.pushState` — so a zoomed-in view can't be shared or
+      bookmarked, and on mobile the back button/gesture exits the page
+      instead of stepping back one zoom level the way users expect. Fixed
+      via a new `app/shared/zoom-url.js` (pure encode/decode of
+      `{mode, window, idPath}` to/from a query string) wired into
+      `mountTreemap`'s new `initialState`/`onNavigate` options and the
+      domain page's inline script: a zoom pushes a history entry (so back
+      steps back one level), a mode/window switch replaces it in place
+      (visible in the URL but not its own undo step), and zooming into a
+      synthetic "N more" bucket touches neither, since its membership
+      isn't stable across modes.
 - [x] Point leaderboard rows at the internal project page instead of the
       project's external homepage. `renderRisingRow` in
       `scripts/render-page.mjs` links each row's name to `entry.link`

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -136,14 +136,44 @@ export function renderDomainPage(
     <script type="module">
       import { mountTreemap } from "${basePath}/shared/treemap.js";
       import { createDetailPanel } from "${basePath}/shared/detail-panel.js";
+      import { parseZoomState, formatZoomState } from "${basePath}/shared/zoom-url.js";
       const mapData = JSON.parse(document.getElementById("map-data").textContent);
       const panel = createDetailPanel(document.body, { historyUrl: "${historyUrl}", basePath: "${basePath}", showProjectPageLink: ${!embed} });
-      mountTreemap(
+      // \`validWindows\` comes from generate.mjs's own RISING_WINDOWS_DAYS
+      // (baked in at build time) rather than a browser-side copy, so this
+      // list can't drift from the one that actually built \`mapData\`.
+      const zoomUrlOptions = { rootId: "${tree.id}", validWindows: ${JSON.stringify(RISING_WINDOWS_DAYS)} };
+      function stateUrl(state) {
+        return location.pathname + formatZoomState(state, zoomUrlOptions) + location.hash;
+      }
+      const initialState = parseZoomState(new URLSearchParams(location.search), zoomUrlOptions);
+      // Gives the very first back-press (after any zoom) a defined entry to
+      // return to, instead of one with no state attached.
+      history.replaceState(initialState, "", stateUrl(initialState));
+      const treemap = mountTreemap(
         document.getElementById("app"),
         mapData,
         (leafData) => panel.open(leafData),
-        () => panel.close()
+        () => panel.close(),
+        {
+          initialState,
+          onNavigate: (state, { replace }) => {
+            if (replace) {
+              history.replaceState(state, "", stateUrl(state));
+            } else {
+              history.pushState(state, "", stateUrl(state));
+            }
+          },
+        }
       );
+      // Restores the treemap to match the URL after a back/forward
+      // navigation — \`event.state\` is whatever was pushed/replaced above,
+      // except on the very first pop back to a page loaded before this
+      // code ever ran a replaceState, when it's null.
+      window.addEventListener("popstate", (event) => {
+        const state = event.state ?? parseZoomState(new URLSearchParams(location.search), zoomUrlOptions);
+        treemap.applyState(state);
+      });
     </script>
     <div class="domain-insights">
       ${categorySection}

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -75,6 +75,25 @@ test("the detail panel is created with a historyUrl pointing at the domain's own
   );
 });
 
+test("the domain page's inline script restores zoom/mode state from the URL on load and replaces the initial history entry with it", () => {
+  const domain = { slug: "data-science", name: "Data Science", description: "desc" };
+  const html = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png", basePath: "" });
+  assert.match(html, /import \{ parseZoomState, formatZoomState \} from "\/shared\/zoom-url\.js"/);
+  assert.match(html, /parseZoomState\(new URLSearchParams\(location\.search\), zoomUrlOptions\)/);
+  assert.match(html, /history\.replaceState\(initialState, "", /);
+  assert.match(html, /mountTreemap\(\s*document\.getElementById\("app"\),\s*mapData,\s*\(leafData\) => panel\.open\(leafData\),\s*\(\) => panel\.close\(\),\s*\{\s*initialState,/);
+});
+
+test("the domain page's inline script mirrors zoom/mode navigation into the URL via history.pushState/replaceState and restores state on popstate", () => {
+  const domain = { slug: "data-science", name: "Data Science", description: "desc" };
+  const html = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png", basePath: "" });
+  assert.match(html, /onNavigate: \(state, \{ replace \}\) => \{/);
+  assert.match(html, /history\.pushState\(state, "", /);
+  assert.match(html, /history\.replaceState\(state, "", /);
+  assert.match(html, /addEventListener\("popstate", \(event\) => \{/);
+  assert.match(html, /treemap\.applyState\(state\)/);
+});
+
 test("the embed variant's detail panel has showProjectPageLink set to false", () => {
   const domain = { slug: "data-science", name: "Data Science", description: "desc" };
   const html = renderDomainPage(domain, ROOT_TREE, { defaultOgImage: "/og-default.png", basePath: "", embed: true });

--- a/test/zoom-url.test.js
+++ b/test/zoom-url.test.js
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseZoomState, formatZoomState } from "../app/shared/zoom-url.js";
+
+const VALID_WINDOWS = [7, 30, 90];
+const ROOT_ID = "web-frameworks";
+
+test("parseZoomState defaults to root/popular/first window when the query string is empty", () => {
+  const state = parseZoomState(new URLSearchParams(""), { rootId: ROOT_ID, validWindows: VALID_WINDOWS });
+  assert.deepEqual(state, { mode: "popular", window: 7, idPath: [ROOT_ID] });
+});
+
+test("parseZoomState reads mode, window, and repeated path segments in order", () => {
+  const state = parseZoomState(new URLSearchParams("mode=rising&window=30&path=frontend&path=react-ecosystem"), {
+    rootId: ROOT_ID,
+    validWindows: VALID_WINDOWS,
+  });
+  assert.deepEqual(state, { mode: "rising", window: 30, idPath: [ROOT_ID, "frontend", "react-ecosystem"] });
+});
+
+test("parseZoomState falls back to popular for an unrecognized mode value", () => {
+  const state = parseZoomState(new URLSearchParams("mode=bogus"), { rootId: ROOT_ID, validWindows: VALID_WINDOWS });
+  assert.equal(state.mode, "popular");
+});
+
+test("parseZoomState falls back to the first valid window for an out-of-range window value", () => {
+  const state = parseZoomState(new URLSearchParams("mode=rising&window=999"), {
+    rootId: ROOT_ID,
+    validWindows: VALID_WINDOWS,
+  });
+  assert.equal(state.window, 7);
+});
+
+test("parseZoomState decodes a percent-encoded path segment", () => {
+  const state = parseZoomState(new URLSearchParams("path=a%20b"), { rootId: ROOT_ID, validWindows: VALID_WINDOWS });
+  assert.deepEqual(state.idPath, [ROOT_ID, "a b"]);
+});
+
+test("formatZoomState returns an empty string for the root/popular/default-window state", () => {
+  const query = formatZoomState(
+    { mode: "popular", window: 7, idPath: [ROOT_ID] },
+    { rootId: ROOT_ID, validWindows: VALID_WINDOWS }
+  );
+  assert.equal(query, "");
+});
+
+test("formatZoomState encodes a zoomed-in rising state with a non-default window", () => {
+  const query = formatZoomState(
+    { mode: "rising", window: 30, idPath: [ROOT_ID, "frontend", "react-ecosystem"] },
+    { rootId: ROOT_ID, validWindows: VALID_WINDOWS }
+  );
+  assert.equal(query, "?path=frontend&path=react-ecosystem&mode=rising&window=30");
+});
+
+test("formatZoomState omits window when mode is popular, even if a rising window was previously set", () => {
+  const query = formatZoomState(
+    { mode: "popular", window: 30, idPath: [ROOT_ID] },
+    { rootId: ROOT_ID, validWindows: VALID_WINDOWS }
+  );
+  assert.equal(query, "");
+});
+
+test("round-trips a category id containing a literal slash (e.g. a 'CI/CD' category name)", () => {
+  const original = { mode: "popular", window: 7, idPath: [ROOT_ID, "CI/CD"] };
+  const query = formatZoomState(original, { rootId: ROOT_ID, validWindows: VALID_WINDOWS });
+  const parsed = parseZoomState(new URLSearchParams(query.slice(1)), { rootId: ROOT_ID, validWindows: VALID_WINDOWS });
+  assert.deepEqual(parsed, original);
+});
+
+test("round-trips a multi-level zoomed rising state through format then parse", () => {
+  const original = { mode: "rising", window: 90, idPath: [ROOT_ID, "frontend", "react-ecosystem"] };
+  const query = formatZoomState(original, { rootId: ROOT_ID, validWindows: VALID_WINDOWS });
+  const parsed = parseZoomState(new URLSearchParams(query.slice(1)), { rootId: ROOT_ID, validWindows: VALID_WINDOWS });
+  assert.deepEqual(parsed, original);
+});


### PR DESCRIPTION
## Summary
Implements the product.md backlog item: a treemap's zoom depth and Popular/Rising mode/window are now reflected in the domain page's URL, so a zoomed-in view can be shared/bookmarked, and the browser back button steps back one zoom level instead of exiting the page.

## Design
- **`app/shared/zoom-url.js`** (new, pure, unit-tested): `parseZoomState`/`formatZoomState` encode/decode `{mode, window, idPath}` to/from a query string. Uses a repeated `path=` param per segment rather than a delimiter-joined value — project ids are `owner/repo` and category names as ordinary as "CI/CD" contain literal `/`, which a single joined+percent-encoded value can't round-trip safely through `URLSearchParams`'s automatic full-value decoding.
- **`app/shared/treemap.js`**: `mountTreemap` gains `{ initialState, onNavigate }`. `initialState` seeds mode/window/zoom before the first render (no flash). `onNavigate(state, { replace })` fires on real navigation: zoom (`replace: false`, pushes a history entry — back steps back one level) vs. mode/window switch (`replace: true`, updates the URL in place without its own undo step). Zooming into a synthetic "N more" (Others) bucket never fires `onNavigate` at all — its membership isn't stable across modes, so it was never a meaningful thing to bookmark. The returned handle gains `applyState(state)`, the inverse used to restore from a `popstate` event without looping back into `onNavigate`.
- **`scripts/render-page.mjs`**: the domain page's inline script parses the initial URL, seeds `mountTreemap`, replaces the initial history entry so the first back-press has something to land on, mirrors `onNavigate` into `history.pushState`/`replaceState`, and restores state on `popstate`.

## Testing
- `test/zoom-url.test.js`: encode/decode round-trips, defaults for missing/invalid input, the literal-`/`-in-a-segment case.
- `test/render-page.test.js`: inline-script wiring assertions, matching the file's existing regex-on-rendered-HTML convention.
- Full suite: 333/333 passing.
- Manual headless-browser (Playwright) pass against a real `npm run generate` build: zoom pushes and back steps back one level; mode/window switch in place; Others zoom touches neither URL nor history; reloading a deep zoomed-in URL restores it without a flash of the root view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)