### PR TITLE
Rewrite homepage hero + add Today's signals module

### DIFF
--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -959,6 +959,67 @@ a.momentum-row-name:hover {
   text-decoration: underline;
 }
 
+.todays-signals {
+  box-sizing: border-box;
+  max-width: 960px;
+  margin: 0 auto 32px;
+  padding: 0 24px;
+}
+
+.todays-signals-heading {
+  font-size: 15px;
+  margin: 0 0 12px;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.signals-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.signal-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: 10px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.15s ease-out, box-shadow 0.15s ease-out;
+}
+
+.signal-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.signal-card-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.signal-card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.signal-card-stat {
+  font-size: 13px;
+  color: var(--color-text);
+}
+
+.signal-card-meta {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
 .project-hero {
   max-width: 640px;
   margin: 0 auto;

--- a/product.md
+++ b/product.md
@@ -18,15 +18,6 @@ this rising" as P1; compare and personalized tracking as P2. Project pages
 and tags (P0/P1) had already landed or were in flight before this review —
 see Shipped, at the end of this file.
 
-- [ ] Rewrite the homepage hero around outcome/discovery ("what's taking
-      off in open source") instead of the current descriptive tagline.
-      `hero-tagline` in `scripts/render-page.mjs` (line 346) still reads
-      "Interactive maps of open-source ecosystems — see which whole
-      ecosystems are heating up..." — accurate, but it explains the product
-      instead of making a visitor want to use it. Pair the new hero with a
-      short "today's signals" teaser (biggest single-project mover, a
-      heating-up ecosystem, a small high-acceleration project to watch)
-      directly beneath it, ahead of the domain grid.
 - [ ] Give the ecosystem map genuine map-like affordances: a growth-based
       color/intensity scale (not just box area for size), and a visual cue
       that distinguishes a "zoom into category" box from an "open project
@@ -160,6 +151,21 @@ need to.
 
 ## Shipped
 
+- [x] Rewrite the homepage hero around outcome/discovery, paired with a
+      "today's signals" teaser (biggest single-project mover, a heating-up
+      ecosystem, a small high-acceleration project to watch) ahead of the
+      domain grid.
+      _Done 2026-08-28: `hero-tagline` in `scripts/render-page.mjs` now reads
+      "What's taking off in open source — spotted by growth, not just
+      stars." The old "Rising this week" teaser on the landing page is
+      replaced by a new `todays-signals` module (`renderTodaysSignals`) fed
+      by a new `scripts/todays-signals.mjs` (`pickTodaysSignals`), reusing
+      an uncapped global leaderboard pool (`computeVelocity`/
+      `computeLeaderboard` now also carry each candidate's `currentStars`)
+      plus the same domain-growth ranking the map cards already use. Each
+      of the three cards is omitted individually when no candidate
+      qualifies, and the whole section is omitted when none do. Domain
+      pages keep their own per-domain teaser unchanged._
 - [x] Reflect zoom depth and mode/window in the URL. `zoomTo`/
       `zoomToOthers` in `app/shared/treemap.js` never call
       `history.pushState` — so a zoomed-in view can't be shared or

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -8,6 +8,7 @@ import { computeProjectSizing, findInvalidSizes, RISING_WINDOWS_DAYS } from "./v
 import { computeLeaderboard } from "./leaderboard.mjs";
 import { computeGroupGrowth, rankGroups } from "./group-growth.mjs";
 import { buildTagGroups, computeTopTags, computeRisingTags } from "./tag-growth.mjs";
+import { pickTodaysSignals } from "./todays-signals.mjs";
 import { buildSitemap, buildRobots } from "./seo.mjs";
 
 const DATA_DIR = "data";
@@ -258,14 +259,22 @@ for (const domain of parsedDomains) {
   });
 }
 
-const globalTeaser = leaderboardsByWindow[TEASER_WINDOW_DAYS].global.slice(0, TEASER_LIMIT);
+// Today's-signals' "one to watch" needs to compare percentDelta across every
+// eligible project, not just the top LEADERBOARD_LIMIT by score — a small,
+// fast-growing project can rank well outside the top 20 on score (which
+// favors absolute gains) while still being the best percentDelta overall.
+// A fresh, uncapped call is cheap at this repo's scale and keeps
+// LEADERBOARD_LIMIT (the /rising/ page's own per-section row count)
+// untouched.
+const globalSignalsPool = computeLeaderboard(parsedDomains, historyBySlug, { scope: "global", windowDays: TEASER_WINDOW_DAYS, limit: Infinity });
+const todaysSignals = pickTodaysSignals(globalSignalsPool, domains);
 writeFileSync(
   `${DIST_DIR}/index.html`,
   renderLandingPage(domains, {
     defaultOgImage: DEFAULT_OG_IMAGE,
     siteUrl: SITE_URL,
     basePath: BASE_PATH,
-    teaser: globalTeaser,
+    signals: todaysSignals,
     momentumWindowDays: MOMENTUM_WINDOW_DAYS,
   })
 );

--- a/scripts/leaderboard.mjs
+++ b/scripts/leaderboard.mjs
@@ -38,6 +38,7 @@ function collectCandidates(domains, historyBySlug, scope, windowDays, asOf) {
         score: velocity.score,
         starDelta: velocity.starDelta,
         percentDelta: velocity.percentDelta,
+        currentStars: velocity.currentStars,
       });
     }
   }
@@ -99,6 +100,7 @@ export function computeLeaderboard(domains, historyBySlug, { scope, windowDays, 
       domainSlug: c.domainSlug,
       starDelta: c.starDelta,
       percentDelta: c.percentDelta,
+      currentStars: c.currentStars,
       rankDelta: yesterdayRankById.get(c.id) - c.rank,
     }));
 }

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -325,7 +325,7 @@ function renderDomainQuicklinks(domains, basePath) {
  * on an answer ("AI is moving fastest this week") instead of an alphabetical
  * index. Untracked domains sort last — see `rankGroups`.
  */
-export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", basePath = "", teaser = [], momentumWindowDays = RISING_WINDOWS_DAYS[0] }) {
+export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", basePath = "", signals = {}, momentumWindowDays = RISING_WINDOWS_DAYS[0] }) {
   const rankedDomains = rankGroups(
     domains.map((domain) => ({
       key: domain.slug,
@@ -353,7 +353,7 @@ export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", baseP
         </a>`;
     })
     .join("");
-  const teaserSection = renderRisingTeaser(teaser, { heading: "Rising this week", href: `${basePath}/rising/`, showDomain: true, basePath });
+  const signalsSection = renderTodaysSignals(signals, { basePath });
   const websiteJsonLd = renderJsonLd(
     buildWebsiteJsonLd({
       name: "awesomemap",
@@ -373,11 +373,11 @@ export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", baseP
       </div>
       <div class="hero-content">
         <h1>awesomemap</h1>
-        <p class="hero-tagline">Interactive maps of open-source ecosystems — see which whole ecosystems are heating up, and which projects inside them are rising fastest.</p>
+        <p class="hero-tagline">What's taking off in open source — spotted by growth, not just stars.</p>
         ${renderDomainQuicklinks(domains, basePath)}
       </div>
     </header>
-    ${teaserSection}
+    ${signalsSection}
     <div class="map-index">
       <h2 class="map-index-heading">Explore the maps</h2>
       <p class="map-index-note">Ranked by how fast each ecosystem grew over the last ${momentumWindowDays} days — growth rate, not size.</p>
@@ -453,6 +453,61 @@ function renderRisingTeaser(entries, { heading, href, showDomain, basePath }) {
       <h2 class="rising-teaser-heading">${escapeHtml(heading)}</h2>
       ${renderRisingRows(entries, { showDomain, basePath })}
       <a class="rising-teaser-link" href="${escapeHtml(href)}">See full leaderboard →</a>
+    </section>`;
+}
+
+/** One card in the landing page's "Today's signals" module — same shape for every signal type, just a different label/title/stat/meta/href. */
+function renderSignalCard({ label, title, stat, meta, href }) {
+  const metaLine = meta ? `<span class="signal-card-meta">${escapeHtml(meta)}</span>` : "";
+  return `
+    <a class="signal-card" href="${escapeHtml(href)}">
+      <span class="signal-card-label">${label}</span>
+      <span class="signal-card-title">${escapeHtml(title)}</span>
+      <span class="signal-card-stat">${stat}</span>
+      ${metaLine}
+    </a>`;
+}
+
+/**
+ * Renders the landing page's "Today's signals" module — up to three cards
+ * (biggest mover, heating-up ecosystem, one-to-watch) built from
+ * `pickTodaysSignals`'s output (see todays-signals.mjs). Any signal that's
+ * `null` (no qualifying candidate yet) is skipped; the whole section is
+ * omitted when none qualify, rather than rendering an empty shell.
+ */
+function renderTodaysSignals({ mover, ecosystem, watch } = {}, { basePath }) {
+  const cards = [
+    mover &&
+      renderSignalCard({
+        label: "🔥 Biggest mover",
+        title: mover.name,
+        stat: `+${mover.starDelta} stars (+${mover.percentDelta.toFixed(1)}%) this week`,
+        meta: mover.domainShort,
+        href: `${basePath}/projects/${mover.id}/`,
+      }),
+    ecosystem &&
+      renderSignalCard({
+        label: "📈 Heating up",
+        title: ecosystem.shortName ?? ecosystem.name,
+        stat: `+${ecosystem.percentDelta.toFixed(1)}% this week`,
+        href: `${basePath}/${ecosystem.slug}/`,
+      }),
+    watch &&
+      renderSignalCard({
+        label: "👀 One to watch",
+        title: watch.name,
+        stat: `+${watch.percentDelta.toFixed(1)}% this week · ★ ${formatStars(watch.currentStars)}`,
+        meta: watch.domainShort,
+        href: `${basePath}/projects/${watch.id}/`,
+      }),
+  ].filter(Boolean);
+
+  if (cards.length === 0) return "";
+
+  return `
+    <section class="todays-signals">
+      <h2 class="todays-signals-heading">Today's signals</h2>
+      <div class="signals-grid">${cards.join("")}</div>
     </section>`;
 }
 

--- a/scripts/todays-signals.mjs
+++ b/scripts/todays-signals.mjs
@@ -1,0 +1,61 @@
+import { rankGroups } from "./group-growth.mjs";
+
+// The largest current star count a project can have and still count as
+// "small" for the `watch` signal — calibrated against this repo's tracked
+// projects (velocity.mjs notes star counts range from ~500 to ~386k, with
+// the 10th percentile around 6,200), so this sits just below that 10th
+// percentile rather than at an arbitrary round number.
+export const SMALL_PROJECT_STAR_THRESHOLD = 5000;
+
+/**
+ * Picks the landing page's three "today's signals" highlights — a reason
+ * to come back daily, per the homepage-hero backlog item's pairing with a
+ * "today's signals" teaser. All three reuse data generate.mjs already
+ * computes elsewhere; this module only selects, it does not derive new
+ * growth math.
+ *
+ * `moverPool` is an *uncapped* global leaderboard for one window (a
+ * `computeLeaderboard` result with `limit` high enough to include every
+ * eligible candidate, not just the top N) — capping it before this
+ * function runs would let a small-but-fast-growing project get cut off
+ * before its `percentDelta` is ever compared for `watch`. `domains` is the
+ * same `{ slug, shortName, growth }` list the landing page's own map-card
+ * ordering ranks via `rankGroups`.
+ *
+ * Each of `mover`/`ecosystem`/`watch` is `null` when no candidate
+ * qualifies (e.g. too early in the dataset's life) — `renderTodaysSignals`
+ * omits that card rather than rendering an empty one.
+ */
+export function pickTodaysSignals(moverPool, domains, { starThreshold = SMALL_PROJECT_STAR_THRESHOLD } = {}) {
+  return {
+    mover: pickBiggestMover(moverPool),
+    ecosystem: pickHeatingUpEcosystem(domains),
+    watch: pickOneToWatch(moverPool, starThreshold),
+  };
+}
+
+/** The candidate with the largest absolute starDelta — deliberately not the top-ranked (by score) candidate, since score already damps large absolute gains in favor of growth rate. */
+function pickBiggestMover(pool) {
+  if (pool.length === 0) return null;
+  return pool.reduce((best, candidate) => (candidate.starDelta > best.starDelta ? candidate : best));
+}
+
+/** The highest-percentDelta candidate among those under `starThreshold` current stars, or null if none qualify. */
+function pickOneToWatch(pool, starThreshold) {
+  const small = pool.filter((candidate) => candidate.currentStars < starThreshold);
+  if (small.length === 0) return null;
+  return small.reduce((best, candidate) => (candidate.percentDelta > best.percentDelta ? candidate : best));
+}
+
+/**
+ * The top domain by growth rate, via the same `rankGroups` ordering the
+ * landing page's map cards already use — untracked domains sort last, so a
+ * tracked top entry is only missing when every domain is untracked.
+ */
+function pickHeatingUpEcosystem(domains) {
+  if (domains.length === 0) return null;
+  const ranked = rankGroups(domains.map((domain) => ({ key: domain.slug, domain, growth: domain.growth })));
+  const top = ranked[0];
+  if (!top.growth.hasEnoughHistory) return null;
+  return { ...top.domain, percentDelta: top.growth.percentDelta };
+}

--- a/scripts/velocity.mjs
+++ b/scripts/velocity.mjs
@@ -36,13 +36,19 @@ export const SCORE_SMOOTHING_CONSTANT = 2000;
  * even for a shrinking project. The smoothing constant keeps a tiny
  * project's noisy swing from outscoring a large project's genuinely
  * bigger gain (see `SCORE_SMOOTHING_CONSTANT`'s doc comment).
+ *
+ * `currentStars` (the latest snapshot's raw star count, 0 when `history`
+ * is empty) rides along on every return path, even an insufficient-history
+ * one — callers that need to tell a small project from a large one (e.g.
+ * picking a "small but fast-growing" highlight) shouldn't have to re-derive
+ * it from `history` themselves.
  */
 export function computeVelocity(history, windowDays, { now = new Date() } = {}) {
   const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
   const oldestDate = sorted.length > 0 ? sorted[0].date : null;
 
   if (sorted.length === 0) {
-    return { score: SCORE_FLOOR, hasEnoughHistory: false, starDelta: 0, percentDelta: 0, oldestDate };
+    return { score: SCORE_FLOOR, hasEnoughHistory: false, starDelta: 0, percentDelta: 0, oldestDate, currentStars: 0 };
   }
 
   const currentStars = sorted[sorted.length - 1].stars;
@@ -55,14 +61,14 @@ export function computeVelocity(history, windowDays, { now = new Date() } = {}) 
   }
 
   if (baseline === null) {
-    return { score: SCORE_FLOOR, hasEnoughHistory: false, starDelta: 0, percentDelta: 0, oldestDate };
+    return { score: SCORE_FLOOR, hasEnoughHistory: false, starDelta: 0, percentDelta: 0, oldestDate, currentStars };
   }
 
   const starDelta = currentStars - baseline.stars;
   const percentDelta = baseline.stars > 0 ? (starDelta / baseline.stars) * 100 : 0;
   const rawScore = starDelta / Math.sqrt(currentStars + SCORE_SMOOTHING_CONSTANT);
 
-  return { score: Math.max(rawScore, SCORE_FLOOR), hasEnoughHistory: true, starDelta, percentDelta, oldestDate };
+  return { score: Math.max(rawScore, SCORE_FLOOR), hasEnoughHistory: true, starDelta, percentDelta, oldestDate, currentStars };
 }
 
 /**

--- a/test/leaderboard.test.js
+++ b/test/leaderboard.test.js
@@ -60,6 +60,14 @@ test("computeLeaderboard ranks by score descending and computes rank movement vs
   assert.equal(aRow.rankDelta, 0); // unchanged at #3
 });
 
+test("computeLeaderboard's rows carry currentStars, the latest snapshot's star count", () => {
+  const result = computeLeaderboard(DOMAINS, HISTORY, { scope: "global", windowDays: 7, limit: 20, now: NOW });
+  const cRow = result.find((r) => r.id === "c/c");
+  assert.equal(cRow.currentStars, 200);
+  const bRow = result.find((r) => r.id === "b/b");
+  assert.equal(bRow.currentStars, 610);
+});
+
 test("computeLeaderboard's domainShort falls back to the full domain name when a domain has no shortName", () => {
   const result = computeLeaderboard(DOMAINS, HISTORY, { scope: "global", windowDays: 7, limit: 20, now: NOW });
   const cRow = result.find((r) => r.id === "c/c");

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -384,22 +384,59 @@ test("renderDomainPage's embed variant has no teaser section", () => {
   assert.doesNotMatch(html, /rising-teaser/);
 });
 
-test("renderLandingPage renders a global teaser section between the hero and the map grid", () => {
-  const teaser = [{ rank: 1, id: "a/a", name: "Project A", link: "https://a.example", domain: "Data Science", starDelta: 40, percentDelta: 40, rankDelta: 0 }];
-  const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], { defaultOgImage: "/og-default.png", teaser });
-  assert.match(html, /class="rising-teaser-link" href="\/rising\/"/);
-  assert.ok(html.indexOf('class="hero"') < html.indexOf('class="rising-teaser"'));
-  assert.ok(html.indexOf('class="rising-teaser"') < html.indexOf('class="map-grid"'));
+test("renderLandingPage no longer renders the old global rising-teaser section", () => {
+  const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], { defaultOgImage: "/og-default.png" });
+  assert.doesNotMatch(html, /rising-teaser/);
 });
 
-test("renderLandingPage's teaser row links at the project's internal page, prefixed by BASE_PATH", () => {
-  const teaser = [{ rank: 1, id: "a/a", name: "Project A", link: "https://a.example", domain: "Data Science", starDelta: 40, percentDelta: 40, rankDelta: 0 }];
+test("renderLandingPage renders a today's-signals section between the hero and the map grid", () => {
+  const signals = {
+    mover: { id: "a/a", name: "Project A", domainShort: "Data Science", starDelta: 400, percentDelta: 40 },
+    ecosystem: { slug: "data-science", shortName: "Data Science", percentDelta: 12 },
+    watch: { id: "b/b", name: "Project B", domainShort: "Security", percentDelta: 80, currentStars: 900 },
+  };
+  const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], { defaultOgImage: "/og-default.png", signals });
+  assert.match(html, /<section class="todays-signals">/);
+  assert.ok(html.indexOf('class="hero"') < html.indexOf('class="todays-signals"'));
+  assert.ok(html.indexOf('class="todays-signals"') < html.indexOf('class="map-grid"'));
+});
+
+test("renderLandingPage's mover and watch signal cards link at the project's internal page, prefixed by BASE_PATH", () => {
+  const signals = {
+    mover: { id: "a/a", name: "Project A", domainShort: "Data Science", starDelta: 400, percentDelta: 40 },
+    ecosystem: null,
+    watch: { id: "b/b", name: "Project B", domainShort: "Security", percentDelta: 80, currentStars: 900 },
+  };
   const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], {
     defaultOgImage: "/og-default.png",
     basePath: "/techmap",
-    teaser,
+    signals,
   });
-  assert.match(html, /<a class="rising-row-name" href="\/techmap\/projects\/a\/a\/">Project A<\/a>/);
+  assert.match(html, /<a class="signal-card" href="\/techmap\/projects\/a\/a\/">[\s\S]*?Project A[\s\S]*?<\/a>/);
+  assert.match(html, /<a class="signal-card" href="\/techmap\/projects\/b\/b\/">[\s\S]*?Project B[\s\S]*?<\/a>/);
+});
+
+test("renderLandingPage's ecosystem signal card links at that domain's own page, prefixed by BASE_PATH", () => {
+  const signals = { mover: null, ecosystem: { slug: "data-science", shortName: "Data Science", percentDelta: 12 }, watch: null };
+  const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], {
+    defaultOgImage: "/og-default.png",
+    basePath: "/techmap",
+    signals,
+  });
+  assert.match(html, /<a class="signal-card" href="\/techmap\/data-science\/">[\s\S]*?Data Science[\s\S]*?<\/a>/);
+});
+
+test("renderLandingPage omits the today's-signals section entirely when no signal qualifies", () => {
+  const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], {
+    defaultOgImage: "/og-default.png",
+    signals: { mover: null, ecosystem: null, watch: null },
+  });
+  assert.doesNotMatch(html, /todays-signals/);
+});
+
+test("renderLandingPage defaults to no today's-signals section when the option is omitted entirely", () => {
+  const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], { defaultOgImage: "/og-default.png" });
+  assert.doesNotMatch(html, /todays-signals/);
 });
 
 test("renderLandingPage's hero includes a quick-jump link per domain, using its short name", () => {

--- a/test/todays-signals.test.js
+++ b/test/todays-signals.test.js
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pickTodaysSignals, SMALL_PROJECT_STAR_THRESHOLD } from "../scripts/todays-signals.mjs";
+
+/** Minimal leaderboard-candidate shape (a computeLeaderboard row). */
+function candidate(overrides) {
+  return {
+    id: "a/a",
+    name: "Project A",
+    domain: "Data Science",
+    domainShort: "Data Science",
+    domainSlug: "data-science",
+    starDelta: 10,
+    percentDelta: 5,
+    currentStars: 1000,
+    ...overrides,
+  };
+}
+
+test("pickTodaysSignals' mover is the candidate with the largest absolute starDelta, not the highest score/rank", () => {
+  const pool = [
+    candidate({ id: "big/big", starDelta: 500, currentStars: 50000 }),
+    candidate({ id: "small/small", starDelta: 20, currentStars: 100 }),
+  ];
+  const { mover } = pickTodaysSignals(pool, []);
+  assert.equal(mover.id, "big/big");
+});
+
+test("pickTodaysSignals' mover is null when the pool is empty", () => {
+  const { mover } = pickTodaysSignals([], []);
+  assert.equal(mover, null);
+});
+
+test("pickTodaysSignals' watch is the highest-percentDelta candidate among those under the small-project star threshold", () => {
+  const pool = [
+    candidate({ id: "big/big", percentDelta: 300, currentStars: 50000 }), // too big to be "small"
+    candidate({ id: "small-slow/small-slow", percentDelta: 10, currentStars: 200 }),
+    candidate({ id: "small-fast/small-fast", percentDelta: 80, currentStars: 300 }),
+  ];
+  const { watch } = pickTodaysSignals(pool, []);
+  assert.equal(watch.id, "small-fast/small-fast");
+});
+
+test("pickTodaysSignals' watch is null when no candidate is under the star threshold", () => {
+  const pool = [candidate({ id: "big/big", currentStars: SMALL_PROJECT_STAR_THRESHOLD + 1 })];
+  const { watch } = pickTodaysSignals(pool, []);
+  assert.equal(watch, null);
+});
+
+test("pickTodaysSignals' ecosystem is the domain with the highest tracked growth, carrying its percentDelta", () => {
+  const domains = [
+    { slug: "security", shortName: "Security", growth: { hasEnoughHistory: true, percentDelta: 2 } },
+    { slug: "ai", shortName: "AI", growth: { hasEnoughHistory: true, percentDelta: 9 } },
+  ];
+  const { ecosystem } = pickTodaysSignals([], domains);
+  assert.equal(ecosystem.slug, "ai");
+  assert.equal(ecosystem.percentDelta, 9);
+});
+
+test("pickTodaysSignals' ecosystem is null when no domain has enough history to rank", () => {
+  const domains = [{ slug: "security", shortName: "Security", growth: { hasEnoughHistory: false, percentDelta: 0 } }];
+  const { ecosystem } = pickTodaysSignals([], domains);
+  assert.equal(ecosystem, null);
+});

--- a/test/velocity.test.js
+++ b/test/velocity.test.js
@@ -16,7 +16,27 @@ test("computeVelocity reports no history for an empty history array", () => {
   assert.equal(result.starDelta, 0);
   assert.equal(result.percentDelta, 0);
   assert.equal(result.oldestDate, null);
+  assert.equal(result.currentStars, 0);
   assert.ok(result.score > 0, "score must stay positive so the treemap never gets a zero/negative weight");
+});
+
+test("computeVelocity reports currentStars as the most recent snapshot's star count", () => {
+  const history = [
+    { date: "2026-07-09", stars: 100 },
+    { date: "2026-08-08", stars: 150 },
+  ];
+  const result = computeVelocity(history, 30, { now: NOW });
+  assert.equal(result.currentStars, 150);
+});
+
+test("computeVelocity reports currentStars even when history is insufficient for the window", () => {
+  const history = [
+    { date: "2026-08-01", stars: 100 },
+    { date: "2026-08-08", stars: 120 },
+  ];
+  const result = computeVelocity(history, 30, { now: NOW });
+  assert.equal(result.hasEnoughHistory, false);
+  assert.equal(result.currentStars, 120);
 });
 
 test("computeVelocity uses a snapshot exactly at the window boundary", () => {


### PR DESCRIPTION
## Summary
Implements the top item on the product backlog (`product.md` → Positioning & discovery experience, now moved to Shipped): rewrites the homepage hero tagline around outcome/discovery, and replaces the landing page's "Rising this week" teaser with a new **Today's signals** module surfacing three highlights:

- 🔥 **Biggest mover** — the global candidate with the largest absolute star delta this week
- 📈 **Heating up** — the domain with the highest tracked growth rate
- 👀 **One to watch** — the highest-%-growth project under a 5,000-star threshold

## Changes
- `scripts/velocity.mjs` — `computeVelocity` now also returns `currentStars`
- `scripts/leaderboard.mjs` — `currentStars` threaded through `computeLeaderboard`'s rows
- `scripts/todays-signals.mjs` (new) — `pickTodaysSignals` selects the three highlights from an uncapped global leaderboard pool + domain growth data
- `scripts/render-page.mjs` — new `renderTodaysSignals`, wired into `renderLandingPage` in place of the old global teaser; domain pages keep their own per-domain teaser unchanged
- `app/shared/treemap.css` — `.todays-signals`/`.signal-card` styles, modeled on the existing `.map-card`
- `scripts/generate.mjs` — computes the uncapped candidate pool and wires signals into the landing page render
- `product.md` — moves the backlog item to Shipped

## Testing
- New/updated unit tests in `test/velocity.test.js`, `test/leaderboard.test.js`, `test/todays-signals.test.js`, `test/render-page.test.js` — all written TDD (red → green)
- `npm test` — 346/346 passing
- `node scripts/generate.mjs` — verified end-to-end against real `data/`, spot-checked the generated `dist/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)