### PR TITLE
MVP item 1: mark data refactor shipped, add + Compare to today's-signals cards

### DIFF
--- a/MVP.md
+++ b/MVP.md
@@ -1,35 +1,22 @@
 # MVP
 
 The current, curated slice of [`product.md`](product.md)'s backlog: the
-seven items judged most important to ship next, in priority order. Unlike
+six items judged most important to ship next, in priority order. Unlike
 `product.md` — an ongoing, non-committal idea list — this file is a
 commitment-shaped shortlist; when an item ships, move it to `product.md`'s
 Shipped section and drop it from here rather than checking it off in place.
 
-1. **[ ] Data structure refactor.** The project/domain shape (`data/<slug>.json`:
-   `slug`/`name`/`shortName`/`description`/`projects[]`) predates tags,
-   project pages, compare, and today's-signals, and each of those landed as
-   its own build-time projection (`tag-growth.mjs`, `compare-index.mjs`,
-   `todays-signals.mjs`) rather than a schema change — so the same project's
-   data is re-derived into a slightly different shape by every consumer, and
-   `data/history/<slug>.json` entries (`buildSnapshotEntry` in
-   `scripts/snapshot-history.mjs`) have grown ad hoc alongside them (stars →
-   stars+forks+openIssues+name+desc, with no versioning). Foundation for the
-   rest of this list, especially #5 and #7, which need domain- and
-   project-level stats read consistently rather than re-assembled per script.
-   Needs its own design pass to settle the target shape before migrating.
-
-2. **[ ] "+ Compare" everywhere.** Already on the detail panel
+1. **[ ] "+ Compare" everywhere.** Already on the detail panel
    (`app/shared/detail-panel.js`), project pages (`renderProjectPage`),
    Rising rows (`renderRisingRow` — homepage teaser, `/rising/`, each
    domain's own teaser), and tag-page rows (`renderTagProjectRow`). Still
    missing from the today's-signals cards (`renderSignalCard` /
    `renderTodaysSignals`, no `compare-toggle`) and from the new top-tags and
-   top-rising-domains surfaces (#6). Close the gap so every place a project
+   top-rising-domains surfaces (#5). Close the gap so every place a project
    id appears in list form carries the same toggle, wired to the existing
    `compare-cart` localStorage logic.
 
-3. **[ ] Rename to "This week's signals."** The homepage module is
+2. **[ ] Rename to "This week's signals."** The homepage module is
    currently headed "Today's signals" (`renderTodaysSignals`,
    `.todays-signals-heading`, fed by `scripts/todays-signals.mjs`), but its
    own card copy already says "this week" (e.g. "+643 stars (+0.4%) this
@@ -40,14 +27,14 @@ Shipped section and drop it from here rather than checking it off in place.
    `product.md`'s broader "site-wide copy pass toward heat/momentum
    language" item.
 
-4. **[ ] Signals per domain.** The global "This week's signals" module
-   (#3) only runs on the homepage — each domain page keeps its own plain
+3. **[ ] Signals per domain.** The global "This week's signals" module
+   (#2) only runs on the homepage — each domain page keeps its own plain
    Rising-rows teaser instead. Reuse the same mover/heating-up/watch
    selection (`pickTodaysSignals`, to become `pickThisWeeksSignals`) scoped
    to one domain's projects, so every domain page gets its own signals
    module, not just a generic leaderboard slice.
 
-5. **[ ] Top rising domains.** `generate.mjs` already computes each
+4. **[ ] Top rising domains.** `generate.mjs` already computes each
    domain's own growth per window (`domainGrowthByWindow`, via
    `computeGroupGrowth`) and threads it onto that domain's landing-page
    card, and `group-growth.mjs`'s `rankGroups` already ranks tags and
@@ -57,7 +44,7 @@ Shipped section and drop it from here rather than checking it off in place.
    alongside "This week's signals," so a visitor can answer "what's hot"
    at the ecosystem level, not just the single-project level.
 
-6. **[ ] Improve compare side-by-side.** `app/shared/compare.js` currently
+5. **[ ] Improve compare side-by-side.** `app/shared/compare.js` currently
    renders one full vertical stat card per project, laid out as sibling
    columns that each repeat the same Stars/7d/30d/90d-growth/Forks/Open-issues
    sequence — not a genuine row-aligned table, so there's no way to scan
@@ -67,7 +54,7 @@ Shipped section and drop it from here rather than checking it off in place.
    narrow viewports, building on the compare-index.json/compare-cart
    plumbing that already shipped.
 
-7. **[ ] Project page: add forks, issues, etc.** `buildSnapshotEntry`
+6. **[ ] Project page: add forks, issues, etc.** `buildSnapshotEntry`
    (`scripts/snapshot-history.mjs`) already captures `forks` and
    `openIssues` in every daily snapshot, and the compare view already
    displays them (`compare.js`'s "Forks"/"Open issues" stat rows) — but

--- a/MVP.md
+++ b/MVP.md
@@ -1,22 +1,12 @@
 # MVP
 
 The current, curated slice of [`product.md`](product.md)'s backlog: the
-six items judged most important to ship next, in priority order. Unlike
+five items judged most important to ship next, in priority order. Unlike
 `product.md` — an ongoing, non-committal idea list — this file is a
 commitment-shaped shortlist; when an item ships, move it to `product.md`'s
 Shipped section and drop it from here rather than checking it off in place.
 
-1. **[ ] "+ Compare" everywhere.** Already on the detail panel
-   (`app/shared/detail-panel.js`), project pages (`renderProjectPage`),
-   Rising rows (`renderRisingRow` — homepage teaser, `/rising/`, each
-   domain's own teaser), and tag-page rows (`renderTagProjectRow`). Still
-   missing from the today's-signals cards (`renderSignalCard` /
-   `renderTodaysSignals`, no `compare-toggle`) and from the new top-tags and
-   top-rising-domains surfaces (#5). Close the gap so every place a project
-   id appears in list form carries the same toggle, wired to the existing
-   `compare-cart` localStorage logic.
-
-2. **[ ] Rename to "This week's signals."** The homepage module is
+1. **[ ] Rename to "This week's signals."** The homepage module is
    currently headed "Today's signals" (`renderTodaysSignals`,
    `.todays-signals-heading`, fed by `scripts/todays-signals.mjs`), but its
    own card copy already says "this week" (e.g. "+643 stars (+0.4%) this
@@ -27,14 +17,14 @@ Shipped section and drop it from here rather than checking it off in place.
    `product.md`'s broader "site-wide copy pass toward heat/momentum
    language" item.
 
-3. **[ ] Signals per domain.** The global "This week's signals" module
-   (#2) only runs on the homepage — each domain page keeps its own plain
+2. **[ ] Signals per domain.** The global "This week's signals" module
+   (#1) only runs on the homepage — each domain page keeps its own plain
    Rising-rows teaser instead. Reuse the same mover/heating-up/watch
    selection (`pickTodaysSignals`, to become `pickThisWeeksSignals`) scoped
    to one domain's projects, so every domain page gets its own signals
    module, not just a generic leaderboard slice.
 
-4. **[ ] Top rising domains.** `generate.mjs` already computes each
+3. **[ ] Top rising domains.** `generate.mjs` already computes each
    domain's own growth per window (`domainGrowthByWindow`, via
    `computeGroupGrowth`) and threads it onto that domain's landing-page
    card, and `group-growth.mjs`'s `rankGroups` already ranks tags and
@@ -44,7 +34,7 @@ Shipped section and drop it from here rather than checking it off in place.
    alongside "This week's signals," so a visitor can answer "what's hot"
    at the ecosystem level, not just the single-project level.
 
-5. **[ ] Improve compare side-by-side.** `app/shared/compare.js` currently
+4. **[ ] Improve compare side-by-side.** `app/shared/compare.js` currently
    renders one full vertical stat card per project, laid out as sibling
    columns that each repeat the same Stars/7d/30d/90d-growth/Forks/Open-issues
    sequence — not a genuine row-aligned table, so there's no way to scan
@@ -54,7 +44,7 @@ Shipped section and drop it from here rather than checking it off in place.
    narrow viewports, building on the compare-index.json/compare-cart
    plumbing that already shipped.
 
-6. **[ ] Project page: add forks, issues, etc.** `buildSnapshotEntry`
+5. **[ ] Project page: add forks, issues, etc.** `buildSnapshotEntry`
    (`scripts/snapshot-history.mjs`) already captures `forks` and
    `openIssues` in every daily snapshot, and the compare view already
    displays them (`compare.js`'s "Forks"/"Open issues" stat rows) — but

--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -1035,19 +1035,31 @@ a.momentum-row-name:hover {
 .signal-card {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
   padding: 16px;
   border-radius: 10px;
   background: var(--color-surface);
   box-shadow: var(--shadow-sm);
-  text-decoration: none;
-  color: inherit;
   transition: transform 0.15s ease-out, box-shadow 0.15s ease-out;
 }
 
 .signal-card:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-md);
+}
+
+.signal-card-link {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.signal-card-compare {
+  align-self: flex-start;
+  font-size: 12px;
+  padding: 2px 10px;
 }
 
 .signal-card-label {

--- a/product.md
+++ b/product.md
@@ -201,6 +201,21 @@ net if the daily jobs that feed it go quiet.
 
 ## Shipped
 
+- [x] "+ Compare" toggle on every remaining surface that lists individual
+      projects — it already covered the detail panel, project pages,
+      Rising rows, and tag-page rows; this closed the last gap, the
+      landing page's "Today's signals" cards (`renderSignalCard`, fed by
+      `pickTodaysSignals`). `renderSignalCard`'s outer element changed
+      from a single `<a>` to a `<div>` wrapping an inner
+      `<a class="signal-card-link">` (the navigable content) plus a
+      sibling `compare-toggle` button — avoids nesting a `<button>`
+      inside an `<a>`, invalid HTML that would also make the button's
+      click bubble into the card's navigation via `compare-cart.js`'s
+      document-wide click delegation. The top-tags widgets and any
+      future top-rising-domains leaderboard list tags/domains, not
+      individual projects, so a compare toggle (which needs a project
+      id) doesn't apply to them.
+      _Done 2026-08-31: MVP item 1 ("+ Compare" everywhere)._
 - [x] On-site project submission, with the human review queue removed
       entirely — data contribution is now hands-off end to end, so
       contributor effort (`CONTRIBUTING.md`) can point entirely at
@@ -232,7 +247,7 @@ net if the daily jobs that feed it go quiet.
       New `scripts/data-store.mjs` is the shared load/save/join layer
       every script now goes through instead of reading
       `data/<slug>.json`/`data/history/<slug>.json` directly.
-      _Done 2026-08-31: MVP item 1._
+      _Done 2026-08-31: MVP item 1 (data structure refactor)._
 - [x] Project comparison view (`/compare/?id=…`), picking 2-4 projects and
       seeing stars, 7/30/90d growth, momentum signal, forks, and open
       issues side by side, plus a cross-page "+ Compare" cart

--- a/product.md
+++ b/product.md
@@ -181,39 +181,6 @@ net if the daily jobs that feed it go quiet.
       re-accumulates, or hand-editing history files. A script to
       recompute/re-derive stored history would make future formula
       changes safe to ship.
-- [ ] Restructure `data/` from one JSON file per domain to one JSON file
-      per project, with domains reduced to thin pointer lists. From a
-      2026-08-31 brainstorm: today `data/<slug>.json` inlines full project
-      metadata per domain (1.3k-1.6k lines each) and
-      `data/history/<slug>.json` inlines per-project star history per
-      domain (2.2k-5.5k lines each) — and worse than just size, a project
-      curated into more than one domain (7 today, e.g. `apache/airflow`
-      in both `automation.json` and `databases.json`) gets an independent
-      copy of its own metadata and history per domain, which can
-      silently drift out of sync since `enrich-domain.mjs` only updates
-      whichever domain file it's pointed at. Proposed shape:
-      `data/domains/<slug>.json` (identity + `{id, path}` pointers only —
-      `path` stays domain-scoped since it's genuinely different per
-      domain for a shared project), `data/projects/<owner>/<repo>.json`
-      (curated metadata), and `data/history/<owner>/<repo>.json` (daily
-      snapshots) — keeps the existing curated-vs-bot-written split the
-      repo already relies on, just re-keyed by project instead of by
-      domain. Touches `generate.mjs` Pass 1, `enrich-domain.mjs`,
-      `snapshot-history.mjs`, the discover/classify/apply-discoveries
-      pipeline, `CONTRIBUTING.md`, and `pr-check.yml`'s validation —
-      architectural scope, needs a written design doc before
-      implementation. Side finding from the same brainstorm: flat
-      per-project files would also make the data cleanly queryable with
-      off-the-shelf SQL-on-JSON tooling (e.g. DuckDB's official Node
-      binding, which reads the file tree directly) for ad hoc maintainer
-      analysis, at no new cost to the production build — evaluated and
-      explicitly not worth pursuing: replacing the production
-      calculation scripts (`velocity.mjs`/`leaderboard.mjs`/
-      `group-growth.mjs`/`tag-growth.mjs`) with SQL (not broken, data
-      volume doesn't need it), or TinyDB in either its Python or npm
-      form (neither is SQL, and both own their storage rather than
-      querying these files in place).
-
 ## Measurement
 
 - [ ] Add privacy-friendly analytics (e.g. Plausible, GoatCounter, Umami —
@@ -254,6 +221,18 @@ net if the daily jobs that feed it go quiet.
       or enrichment failure is simply retried on a later run instead of
       waiting on a human.
       _Done 2026-08-31._
+- [x] Restructured `data/` from one JSON file per domain to one JSON file
+      per project, with domains reduced to thin pointer lists.
+      `data/domains/<slug>.json` now holds identity + `{id, path}`
+      pointers only (`path` stays domain-scoped since it's genuinely
+      different per domain for a shared project), and
+      `data/projects/<owner>/<repo>.json` holds curated metadata plus its
+      own history array — no more independent per-domain copies of a
+      shared project's metadata/history silently drifting out of sync.
+      New `scripts/data-store.mjs` is the shared load/save/join layer
+      every script now goes through instead of reading
+      `data/<slug>.json`/`data/history/<slug>.json` directly.
+      _Done 2026-08-31: MVP item 1._
 - [x] Project comparison view (`/compare/?id=…`), picking 2-4 projects and
       seeing stars, 7/30/90d growth, momentum signal, forks, and open
       issues side by side, plus a cross-page "+ Compare" cart

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -487,16 +487,30 @@ function renderRisingTeaser(entries, { heading, href, showDomain, basePath }) {
     </section>`;
 }
 
-/** One card in the landing page's "Today's signals" module — same shape for every signal type, just a different label/title/stat/meta/href. */
-function renderSignalCard({ label, title, stat, meta, href }) {
+/**
+ * One card in the landing page's "Today's signals" module — same shape for
+ * every signal type, just a different label/title/stat/meta/href. The
+ * navigable content lives in an inner `<a>` rather than making the whole
+ * card a link, so the `compare-toggle` button (`compareId`, when the
+ * signal has a project id) can sit alongside it as its own click target
+ * instead of nesting a `<button>` inside an `<a>` — invalid HTML that
+ * would also make the button's click bubble into the card's navigation.
+ */
+function renderSignalCard({ label, title, stat, meta, href, compareId }) {
   const metaLine = meta ? `<span class="signal-card-meta">${escapeHtml(meta)}</span>` : "";
+  const compareToggle = compareId
+    ? `<button type="button" class="signal-card-compare compare-toggle" data-compare-id="${escapeHtml(compareId)}" aria-pressed="false">+ Compare</button>`
+    : "";
   return `
-    <a class="signal-card" href="${escapeHtml(href)}">
-      <span class="signal-card-label">${label}</span>
-      <span class="signal-card-title">${escapeHtml(title)}</span>
-      <span class="signal-card-stat">${stat}</span>
-      ${metaLine}
-    </a>`;
+    <div class="signal-card">
+      <a class="signal-card-link" href="${escapeHtml(href)}">
+        <span class="signal-card-label">${label}</span>
+        <span class="signal-card-title">${escapeHtml(title)}</span>
+        <span class="signal-card-stat">${stat}</span>
+        ${metaLine}
+      </a>
+      ${compareToggle}
+    </div>`;
 }
 
 /**
@@ -515,6 +529,7 @@ function renderTodaysSignals({ mover, heatingUp, watch } = {}, { basePath }) {
         stat: `+${mover.starDelta} stars (+${mover.percentDelta.toFixed(1)}%) this week`,
         meta: mover.domainShort,
         href: `${basePath}/projects/${mover.id}/`,
+        compareId: mover.id,
       }),
     heatingUp &&
       renderSignalCard({
@@ -523,6 +538,7 @@ function renderTodaysSignals({ mover, heatingUp, watch } = {}, { basePath }) {
         stat: `+${heatingUp.percentDelta.toFixed(1)}% this week`,
         meta: heatingUp.domainShort,
         href: `${basePath}/projects/${heatingUp.id}/`,
+        compareId: heatingUp.id,
       }),
     watch &&
       renderSignalCard({
@@ -531,6 +547,7 @@ function renderTodaysSignals({ mover, heatingUp, watch } = {}, { basePath }) {
         stat: `+${watch.percentDelta.toFixed(1)}% this week · ★ ${formatStars(watch.currentStars)}`,
         meta: watch.domainShort,
         href: `${basePath}/projects/${watch.id}/`,
+        compareId: watch.id,
       }),
   ].filter(Boolean);
 

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -458,8 +458,20 @@ test("renderLandingPage's mover and watch signal cards link at the project's int
     basePath: "/techmap",
     signals,
   });
-  assert.match(html, /<a class="signal-card" href="\/techmap\/projects\/a\/a\/">[\s\S]*?Project A[\s\S]*?<\/a>/);
-  assert.match(html, /<a class="signal-card" href="\/techmap\/projects\/b\/b\/">[\s\S]*?Project B[\s\S]*?<\/a>/);
+  assert.match(html, /<a class="signal-card-link" href="\/techmap\/projects\/a\/a\/">[\s\S]*?Project A[\s\S]*?<\/a>/);
+  assert.match(html, /<a class="signal-card-link" href="\/techmap\/projects\/b\/b\/">[\s\S]*?Project B[\s\S]*?<\/a>/);
+});
+
+test("renderLandingPage's signal cards each carry a compare-toggle button for their project id", () => {
+  const signals = {
+    mover: { id: "a/a", name: "Project A", domainShort: "Data Science", starDelta: 400, percentDelta: 40 },
+    heatingUp: { id: "c/c", name: "Project C", domainShort: "Data Science", percentDelta: 12 },
+    watch: { id: "b/b", name: "Project B", domainShort: "Security", percentDelta: 80, currentStars: 900 },
+  };
+  const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], { defaultOgImage: "/og-default.png", signals });
+  assert.match(html, /<button type="button" class="signal-card-compare compare-toggle" data-compare-id="a\/a" aria-pressed="false">\+ Compare<\/button>/);
+  assert.match(html, /<button type="button" class="signal-card-compare compare-toggle" data-compare-id="c\/c" aria-pressed="false">\+ Compare<\/button>/);
+  assert.match(html, /<button type="button" class="signal-card-compare compare-toggle" data-compare-id="b\/b" aria-pressed="false">\+ Compare<\/button>/);
 });
 
 test("renderLandingPage's heatingUp signal card links at that project's own internal page, prefixed by BASE_PATH", () => {
@@ -469,7 +481,7 @@ test("renderLandingPage's heatingUp signal card links at that project's own inte
     basePath: "/techmap",
     signals,
   });
-  assert.match(html, /<a class="signal-card" href="\/techmap\/projects\/c\/c\/">[\s\S]*?Project C[\s\S]*?<\/a>/);
+  assert.match(html, /<a class="signal-card-link" href="\/techmap\/projects\/c\/c\/">[\s\S]*?Project C[\s\S]*?<\/a>/);
 });
 
 test("renderLandingPage omits the today's-signals section entirely when no signal qualifies", () => {


### PR DESCRIPTION
## Summary
- Housekeeping: MVP item 1 ("Data structure refactor") had already shipped in code (`e059d27`) but was never checked off in `MVP.md` — moved it to `product.md`'s Shipped section.
- Implemented the next MVP item, **"+ Compare" everywhere**: added the compare-toggle button to the landing page's "Today's signals" cards, the one remaining project-list surface without it. Restructured `renderSignalCard` so the button isn't nested inside an `<a>` (invalid HTML that would also make its click bubble into the card's navigation).
- Marked that item shipped too and renumbered `MVP.md`'s remaining backlog (now 5 items, next up: rename "Today's signals" → "This week's signals").

## Test plan
- `npm test` — all 377 applicable tests pass (`test/layout.test.js` has a pre-existing, unrelated `ERR_MODULE_NOT_FOUND` failure, confirmed present before this branch's changes too).
- `npm run generate` — site builds; verified 3 compare-toggle buttons render on the generated homepage's signal cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)