### PR TITLE
feat: row-per-stat compare grid with winner highlighting (MVP item 4)

### DIFF
--- a/MVP.md
+++ b/MVP.md
@@ -1,7 +1,7 @@
 # MVP
 
 The current, curated slice of [`product.md`](product.md)'s backlog: the
-five items judged most important to ship next, in priority order. Unlike
+four items judged most important to ship next, in priority order. Unlike
 `product.md` — an ongoing, non-committal idea list — this file is a
 commitment-shaped shortlist; when an item ships, move it to `product.md`'s
 Shipped section and drop it from here rather than checking it off in place.
@@ -34,17 +34,7 @@ Shipped section and drop it from here rather than checking it off in place.
    alongside "This week's signals," so a visitor can answer "what's hot"
    at the ecosystem level, not just the single-project level.
 
-4. **[ ] Improve compare side-by-side.** `app/shared/compare.js` currently
-   renders one full vertical stat card per project, laid out as sibling
-   columns that each repeat the same Stars/7d/30d/90d-growth/Forks/Open-issues
-   sequence — not a genuine row-aligned table, so there's no way to scan
-   "who's winning on 30d growth" across projects at a glance, and no
-   highlighting of the best value per stat. Restructure into a real
-   row-per-stat grid with a winner highlight, and tighten the layout for
-   narrow viewports, building on the compare-index.json/compare-cart
-   plumbing that already shipped.
-
-5. **[ ] Project page: add forks, issues, etc.** `buildSnapshotEntry`
+4. **[ ] Project page: add forks, issues, etc.** `buildSnapshotEntry`
    (`scripts/snapshot-history.mjs`) already captures `forks` and
    `openIssues` in every daily snapshot, and the compare view already
    displays them (`compare.js`'s "Forks"/"Open issues" stat rows) — but

--- a/app/shared/compare.js
+++ b/app/shared/compare.js
@@ -12,9 +12,51 @@ import { removeFromCart, refreshCompareButtons } from "./compare-cart.js";
 const RISING_WINDOWS_DAYS = [7, 30, 90];
 
 /**
+ * The stats table's rows, in display order. Each row knows how to render
+ * its own cell text (`cell`) and, for rows where "biggest number wins" is
+ * an unambiguous claim, how to pull the comparable number out of a record
+ * (`winnerValue`) so `winnersForRow` can highlight the best column(s).
+ * `winnerValue` is `null` for rows where a bigger number isn't obviously
+ * "better" (a narrative sentence, or an open-issue count) — no winner is
+ * ever computed or highlighted for those.
+ */
+const STAT_ROWS = [
+  {
+    label: "Stars",
+    cell: (record) => `★ ${formatStarCount(record.weight) ?? "—"}`,
+    winnerValue: (record) => record.weight,
+  },
+  ...RISING_WINDOWS_DAYS.map((windowDays) => {
+    const key = `rising${windowDays}`;
+    return {
+      label: `${windowDays}d growth`,
+      cell: (record) => formatGrowthCell(record.growth[key], record.hasEnoughHistory[key]),
+      // Only a window with enough history is a trustworthy comparison point
+      // — matches formatGrowthCell's own "Not enough history yet" gate.
+      winnerValue: (record) => (record.hasEnoughHistory[key] ? record.growth[key]?.percentDelta : null),
+    };
+  }),
+  {
+    label: "Momentum",
+    cell: (record) => record.signalHeadline ?? "—",
+    winnerValue: null, // a narrative sentence, not a single comparable number
+  },
+  {
+    label: "Forks",
+    cell: (record) => formatCount(record.forks),
+    winnerValue: (record) => (typeof record.forks === "number" ? record.forks : null),
+  },
+  {
+    label: "Open issues",
+    cell: (record) => formatCount(record.openIssues),
+    winnerValue: null, // more open issues isn't unambiguously better or worse, unlike stars/growth/forks
+  },
+];
+
+/**
  * Mounts the /compare/ page's table into `container`. Fetches
  * `compareIndexUrl` once (cached for the mount's lifetime), renders one
- * column per id in `initialIds` plus an "add project" column, and calls
+ * header card per id in `initialIds` plus an "add project" card, and calls
  * `onIdsChange(ids)` whenever the visible id list changes via the add box
  * or a column's remove button — this function never touches
  * `history`/`location` itself, the same split render-page.mjs's inline
@@ -24,7 +66,6 @@ const RISING_WINDOWS_DAYS = [7, 30, 90];
  */
 export function mountCompare(container, { compareIndexUrl, basePath = "", initialIds, onIdsChange }) {
   const root = document.createElement("div");
-  root.className = "compare-grid";
   container.appendChild(root);
 
   let index = null;
@@ -52,19 +93,100 @@ export function mountCompare(container, { compareIndexUrl, basePath = "", initia
     if (index) render();
   });
 
+  // `index` is a JSON.parse result, so it inherits from Object.prototype —
+  // a truthy `index[id]` check would treat inherited keys like
+  // "constructor"/"toString" as found records. Object.hasOwn checks own
+  // enumerable-or-not properties only, so an id that merely collides with a
+  // prototype member correctly falls through to "not found".
+  function recordFor(id) {
+    return index && Object.hasOwn(index, id) ? index[id] : null;
+  }
+
   function render() {
     root.innerHTML = "";
+
+    const headerRow = document.createElement("div");
+    headerRow.className = "compare-grid";
     for (const id of currentIds) {
-      // `index` is a JSON.parse result, so it inherits from Object.prototype
-      // — a truthy `index[id]` check would treat inherited keys like
-      // "constructor"/"toString" as found records. Object.hasOwn checks own
-      // enumerable-or-not properties only, so an id that merely collides
-      // with a prototype member correctly falls through to "not found".
-      root.appendChild(Object.hasOwn(index, id) ? renderColumn(index[id]) : renderNotFoundColumn(id));
+      const record = recordFor(id);
+      headerRow.appendChild(record ? renderHeaderCell(record) : renderNotFoundColumn(id));
     }
     if (currentIds.length < MAX_COMPARE_IDS) {
-      root.appendChild(renderAddColumn());
+      headerRow.appendChild(renderAddColumn());
     }
+    root.appendChild(headerRow);
+
+    // Nothing to tabulate with zero resolved records (e.g. every id in the
+    // URL is stale) — the header row's "not found" placeholders already say
+    // so, a stats table with only a label column and no data would just be
+    // noise on top of that.
+    if (currentIds.some((id) => recordFor(id))) {
+      root.appendChild(renderStatsTable());
+    }
+  }
+
+  /** Builds the `{ [id]: winning }` map for one STAT_ROWS row: the set of ids tied for the row's best value, or `null` when the row has no `winnerValue` getter, fewer than two comparable values, or every comparable value ties. */
+  function winnersForRow(getValue) {
+    const values = [];
+    for (const id of currentIds) {
+      const record = recordFor(id);
+      if (!record) continue;
+      const value = getValue(record);
+      if (typeof value === "number" && Number.isFinite(value)) values.push([id, value]);
+    }
+    if (values.length < 2) return null;
+    const max = Math.max(...values.map(([, value]) => value));
+    if (values.every(([, value]) => value === max)) return null; // an across-the-board tie has nothing to highlight
+    return new Set(values.filter(([, value]) => value === max).map(([id]) => id));
+  }
+
+  /**
+   * The row-per-stat grid: one row per STAT_ROWS entry, one column per id in
+   * `currentIds` (a "—" cell for an id that didn't resolve, so columns stay
+   * aligned with the header row above), with the best value per row
+   * highlighted. Wrapped by the caller in a horizontally-scrollable
+   * container with a sticky label column, since up to 4 project columns
+   * plus an add column don't fit a narrow viewport.
+   */
+  function renderStatsTable() {
+    const wrap = document.createElement("div");
+    wrap.className = "compare-table-wrap";
+
+    const table = document.createElement("table");
+    table.className = "compare-table";
+    table.setAttribute("aria-label", "Stat-by-stat comparison");
+
+    const tbody = document.createElement("tbody");
+    for (const row of STAT_ROWS) {
+      const tr = document.createElement("tr");
+      const winners = row.winnerValue ? winnersForRow(row.winnerValue) : null;
+
+      const th = document.createElement("th");
+      th.scope = "row";
+      th.className = "compare-row-label";
+      th.textContent = row.label;
+      tr.appendChild(th);
+
+      for (const id of currentIds) {
+        const record = recordFor(id);
+        const td = document.createElement("td");
+        if (record) {
+          td.textContent = row.cell(record);
+          if (winners?.has(id)) td.classList.add("compare-winner");
+        } else {
+          td.textContent = "—";
+          td.className = "compare-cell-empty";
+        }
+        tr.appendChild(td);
+      }
+      if (currentIds.length < MAX_COMPARE_IDS) {
+        tr.appendChild(document.createElement("td")); // keeps this row under the add column, empty since it has nothing to add
+      }
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    wrap.appendChild(table);
+    return wrap;
   }
 
   function removeButton(id) {
@@ -100,7 +222,8 @@ export function mountCompare(container, { compareIndexUrl, basePath = "", initia
     return column;
   }
 
-  function renderColumn(record) {
+  /** The header row's per-project card: identity (logo, name, domain, description, tags) and outbound links. Numeric stats live in the table below, not here — see STAT_ROWS. */
+  function renderHeaderCell(record) {
     const column = document.createElement("div");
     column.className = "compare-column";
     column.appendChild(removeButton(record.id));
@@ -137,20 +260,6 @@ export function mountCompare(container, { compareIndexUrl, basePath = "", initia
     const tagList = renderTagChips(record.tags, basePath);
     if (tagList) column.appendChild(tagList);
 
-    column.appendChild(statRow("Stars", `★ ${formatStarCount(record.weight) ?? "—"}`));
-    for (const windowDays of RISING_WINDOWS_DAYS) {
-      const key = `rising${windowDays}`;
-      column.appendChild(statRow(`${windowDays}d growth`, formatGrowthCell(record.growth[key], record.hasEnoughHistory[key])));
-    }
-    if (record.signalHeadline) {
-      const signal = document.createElement("p");
-      signal.className = "compare-stat compare-signal";
-      signal.textContent = record.signalHeadline;
-      column.appendChild(signal);
-    }
-    column.appendChild(statRow("Forks", formatCount(record.forks)));
-    column.appendChild(statRow("Open issues", formatCount(record.openIssues)));
-
     if (record.link) {
       const siteLink = document.createElement("a");
       siteLink.className = "detail-panel-link";
@@ -170,18 +279,6 @@ export function mountCompare(container, { compareIndexUrl, basePath = "", initia
     column.appendChild(githubLink);
 
     return column;
-  }
-
-  /** One labeled stat row, e.g. "Stars" / "★ 12,400" — the compare table's basic building block, reused for every numeric/growth row. */
-  function statRow(label, value) {
-    const row = document.createElement("p");
-    row.className = "compare-stat";
-    const labelEl = document.createElement("span");
-    labelEl.className = "compare-stat-label";
-    labelEl.textContent = label;
-    row.appendChild(labelEl);
-    row.appendChild(document.createTextNode(value));
-    return row;
   }
 
   function renderAddColumn() {
@@ -211,7 +308,7 @@ export function mountCompare(container, { compareIndexUrl, basePath = "", initia
       error.textContent = "";
       const id = normalizeProjectId(input.value);
       if (!id) return;
-      if (!index || !Object.hasOwn(index, id)) {
+      if (!recordFor(id)) {
         error.textContent = `Couldn't find "${id}".`;
         return;
       }

--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -1231,28 +1231,6 @@ a.momentum-row-name:hover {
   color: var(--color-text-muted);
 }
 
-.compare-stat {
-  text-align: left;
-  font-size: 13px;
-  border-top: 1px solid var(--color-border);
-  padding: 6px 0;
-  margin: 0;
-}
-
-.compare-stat-label {
-  display: block;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.compare-signal {
-  color: var(--color-accent);
-  font-weight: 600;
-}
-
 .compare-add-column {
   border-style: dashed;
 }
@@ -1267,6 +1245,57 @@ a.momentum-row-name:hover {
   color: var(--color-rising-down);
   font-size: 12px;
   min-height: 1em;
+}
+
+/* Row-per-stat grid below the header cards: one row per stat (Stars, 7/30/
+   90d growth, Momentum, Forks, Open issues), one column per project, so
+   "who's winning on 30d growth" is a scan across a row instead of hunting
+   through stacked per-project cards. Horizontally scrollable rather than
+   reflowing to one-column-per-row on narrow viewports (compare.js's old
+   stacked-card layout did that) — a comparison table that drops its column
+   alignment on mobile stops being a comparison. */
+.compare-table-wrap {
+  margin-top: 16px;
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+}
+
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.compare-table tr:not(:last-child) th,
+.compare-table tr:not(:last-child) td {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.compare-table th,
+.compare-table td {
+  padding: 8px 12px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.compare-row-label {
+  position: sticky;
+  left: 0;
+  background: var(--color-surface);
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.compare-cell-empty {
+  color: var(--color-text-muted);
+}
+
+.compare-winner {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-weight: 600;
 }
 
 @media (max-width: 480px) {

--- a/product.md
+++ b/product.md
@@ -201,6 +201,26 @@ net if the daily jobs that feed it go quiet.
 
 ## Shipped
 
+- [x] Row-per-stat compare grid with a winner highlight.
+      `app/shared/compare.js`'s `/compare/` table used to render one full
+      vertical stat card per project as sibling columns — Stars/7d/30d/90d
+      growth/Forks/Open issues each repeated per column, with no way to
+      scan "who's winning on 30d growth" across projects at a glance.
+      `renderColumn` is now `renderHeaderCell` (identity only: logo, name,
+      domain, description, tags, links); a new `renderStatsTable`/
+      `STAT_ROWS` builds a real `<table>` below it with one row per stat and
+      one column per project, and `winnersForRow` highlights the best
+      value(s) per row (`.compare-winner`) for the rows where "biggest
+      number wins" is unambiguous — stars, each growth window (by percent,
+      gated on `hasEnoughHistory` the same as `formatGrowthCell` already
+      was), and forks. Momentum (a narrative sentence) and open issues
+      (more isn't obviously better or worse) are shown but never
+      highlighted. Narrow viewports get a horizontally-scrollable table
+      with a `position: sticky` stat-label column, replacing the old
+      one-column-per-row stacking that would otherwise have thrown away
+      row alignment on mobile, exactly where a comparison table needs it
+      most.
+      _Done 2026-09-01: MVP item 4 ("Improve compare side-by-side")._
 - [x] "+ Compare" toggle on every remaining surface that lists individual
       projects — it already covered the detail panel, project pages,
       Rising rows, and tag-page rows; this closed the last gap, the


### PR DESCRIPTION
## Summary
`/compare/` used to render one full vertical stat card per project as sibling columns — Stars/7d/30d/90d growth/Forks/Open issues each repeated per column, with no way to scan "who's winning on 30d growth" across projects at a glance.

- `compare.js`: `renderColumn` → `renderHeaderCell` (identity only: logo, name, domain, description, tags, links). New `renderStatsTable` + `STAT_ROWS` build a real `<table>` below it, one row per stat, one column per project. `winnersForRow` highlights the best value(s) per row (`.compare-winner`) for stats where "biggest number wins" is unambiguous: stars, each growth window (by percent, gated on `hasEnoughHistory` the same as `formatGrowthCell` already was), and forks. Momentum (a narrative sentence) and open issues (more isn't clearly better or worse) are shown but never highlighted.
- `treemap.css`: table styles, plus a horizontally-scrollable `.compare-table-wrap` with a sticky stat-label column for narrow viewports, replacing the old one-column-per-row stacking that threw away row alignment on mobile.
- `product.md`/`MVP.md`: move MVP item 4 to `product.md`'s Shipped section.

## Verification
- Headless-browser pass against real data (`openclaw/openclaw` vs `NousResearch/hermes-agent`): OpenClaw wins Stars and Forks, Hermes Agent wins 7d growth — exactly the "bigger vs faster-growing" story the winner highlight is meant to surface. Confirmed on desktop and mobile viewports, including the sticky-column scroll behavior.
- `npm test`: 377/378 passing — unchanged from `master` (the one failure is a pre-existing, unrelated missing `d3-hierarchy` module in this sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)