### PR TITLE
rename: "Today's signals" homepage module -> "This week's signals" (MVP item 1)

### DIFF
--- a/MVP.md
+++ b/MVP.md
@@ -1,30 +1,19 @@
 # MVP
 
 The current, curated slice of [`product.md`](product.md)'s backlog: the
-four items judged most important to ship next, in priority order. Unlike
+three items judged most important to ship next, in priority order. Unlike
 `product.md` — an ongoing, non-committal idea list — this file is a
 commitment-shaped shortlist; when an item ships, move it to `product.md`'s
 Shipped section and drop it from here rather than checking it off in place.
 
-1. **[ ] Rename to "This week's signals."** The homepage module is
-   currently headed "Today's signals" (`renderTodaysSignals`,
-   `.todays-signals-heading`, fed by `scripts/todays-signals.mjs`), but its
-   own card copy already says "this week" (e.g. "+643 stars (+0.4%) this
-   week"), and the README's equivalent feature is literally titled "This
-   week's biggest risers." Rename the heading, CSS classes, and module
-   (`todays-signals.mjs` → `this-weeks-signals.mjs`, `pickTodaysSignals` →
-   `pickThisWeeksSignals`) for one consistent name, as the first slice of
-   `product.md`'s broader "site-wide copy pass toward heat/momentum
-   language" item.
-
-2. **[ ] Signals per domain.** The global "This week's signals" module
-   (#1) only runs on the homepage — each domain page keeps its own plain
+1. **[ ] Signals per domain.** The global "This week's signals" module
+   only runs on the homepage — each domain page keeps its own plain
    Rising-rows teaser instead. Reuse the same mover/heating-up/watch
-   selection (`pickTodaysSignals`, to become `pickThisWeeksSignals`) scoped
-   to one domain's projects, so every domain page gets its own signals
-   module, not just a generic leaderboard slice.
+   selection (`pickThisWeeksSignals`) scoped to one domain's projects, so
+   every domain page gets its own signals module, not just a generic
+   leaderboard slice.
 
-3. **[ ] Top rising domains.** `generate.mjs` already computes each
+2. **[ ] Top rising domains.** `generate.mjs` already computes each
    domain's own growth per window (`domainGrowthByWindow`, via
    `computeGroupGrowth`) and threads it onto that domain's landing-page
    card, and `group-growth.mjs`'s `rankGroups` already ranks tags and
@@ -34,7 +23,7 @@ Shipped section and drop it from here rather than checking it off in place.
    alongside "This week's signals," so a visitor can answer "what's hot"
    at the ecosystem level, not just the single-project level.
 
-4. **[ ] Project page: add forks, issues, etc.** `buildSnapshotEntry`
+3. **[ ] Project page: add forks, issues, etc.** `buildSnapshotEntry`
    (`scripts/snapshot-history.mjs`) already captures `forks` and
    `openIssues` in every daily snapshot, and the compare view already
    displays them (`compare.js`'s "Forks"/"Open issues" stat rows) — but

--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -1011,14 +1011,14 @@ a.momentum-row-name:hover {
   text-decoration: underline;
 }
 
-.todays-signals {
+.this-weeks-signals {
   box-sizing: border-box;
   max-width: 960px;
   margin: 0 auto 32px;
   padding: 0 24px;
 }
 
-.todays-signals-heading {
+.this-weeks-signals-heading {
   font-size: 15px;
   margin: 0 0 12px;
   color: var(--color-text-muted);

--- a/product.md
+++ b/product.md
@@ -83,9 +83,9 @@ see Shipped, at the end of this file.
 - [ ] Site-wide copy pass toward heat/momentum/discovery language, e.g.
       "🔥 What's heating up" instead of "Rising stars," "🗺 Explore the
       ecosystems" instead of "Explore the maps." Low-effort, and ties
-      together every item above into one consistent voice. `MVP.md` item
-      #4 (renaming "Today's signals" to "This week's signals") is the
-      first slice of this.
+      together every item above into one consistent voice. Renaming
+      "Today's signals" to "This week's signals" was the first slice of
+      this (see Shipped).
 - [ ] Longer-term: personalized tracking — "follow" a domain/category/tag
       and get a "N things changed since your last visit" digest. No
       accounts or persistence exist today; sequence this after search and
@@ -221,11 +221,22 @@ net if the daily jobs that feed it go quiet.
       row alignment on mobile, exactly where a comparison table needs it
       most.
       _Done 2026-09-01: MVP item 4 ("Improve compare side-by-side")._
+- [x] Renamed the homepage's "Today's signals" module to "This week's
+      signals," matching its own card copy (e.g. "+643 stars (+0.4%) this
+      week") and the README's "This week's biggest risers" language: the
+      heading and CSS classes (`.todays-signals` → `.this-weeks-signals`,
+      `.todays-signals-heading` → `.this-weeks-signals-heading`), the
+      render function (`renderTodaysSignals` → `renderThisWeeksSignals`),
+      and the module itself (`scripts/todays-signals.mjs` →
+      `scripts/this-weeks-signals.mjs`, `pickTodaysSignals` →
+      `pickThisWeeksSignals`). First slice of the "site-wide copy pass
+      toward heat/momentum language" item above.
+      _Done 2026-09-01: MVP item 1 (the "This week's signals" rename)._
 - [x] "+ Compare" toggle on every remaining surface that lists individual
       projects — it already covered the detail panel, project pages,
       Rising rows, and tag-page rows; this closed the last gap, the
-      landing page's "Today's signals" cards (`renderSignalCard`, fed by
-      `pickTodaysSignals`). `renderSignalCard`'s outer element changed
+      landing page's "This week's signals" cards (`renderSignalCard`, fed
+      by `pickThisWeeksSignals`). `renderSignalCard`'s outer element changed
       from a single `<a>` to a `<div>` wrapping an inner
       `<a class="signal-card-link">` (the navigable content) plus a
       sibling `compare-toggle` button — avoids nesting a `<button>`
@@ -295,15 +306,16 @@ net if the daily jobs that feed it go quiet.
       by fork/contributor movement) remains the separate "statistical
       anomaly detection" item below, still unbuilt._
 - [x] Rewrite the homepage hero around outcome/discovery, paired with a
-      "today's signals" teaser (biggest single-project mover, a heating-up
-      ecosystem, a small high-acceleration project to watch) ahead of the
-      domain grid.
+      "this week's signals" teaser (biggest single-project mover, a
+      heating-up ecosystem, a small high-acceleration project to watch)
+      ahead of the domain grid.
       _Done 2026-08-28: `hero-tagline` in `scripts/render-page.mjs` now reads
       "What's taking off in open source — spotted by growth, not just
       stars." The old "Rising this week" teaser on the landing page is
-      replaced by a new `todays-signals` module (`renderTodaysSignals`) fed
-      by a new `scripts/todays-signals.mjs` (`pickTodaysSignals`), reusing
-      an uncapped global leaderboard pool (`computeVelocity`/
+      replaced by a new `this-weeks-signals` module (`renderThisWeeksSignals`)
+      fed by a new `scripts/this-weeks-signals.mjs` (`pickThisWeeksSignals`,
+      renamed from `todays-signals.mjs`/`pickTodaysSignals` by MVP item 1 on
+      2026-09-01), reusing an uncapped global leaderboard pool (`computeVelocity`/
       `computeLeaderboard` now also carry each candidate's `currentStars`)
       plus the same domain-growth ranking the map cards already use. Each
       of the three cards is omitted individually when no candidate

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -9,7 +9,7 @@ import { computeProjectSizing, findInvalidSizes, RISING_WINDOWS_DAYS } from "./v
 import { computeLeaderboard } from "./leaderboard.mjs";
 import { computeGroupGrowth, rankGroups } from "./group-growth.mjs";
 import { buildTagGroups, computeTopTags, computeRisingTags } from "./tag-growth.mjs";
-import { pickTodaysSignals } from "./todays-signals.mjs";
+import { pickThisWeeksSignals } from "./this-weeks-signals.mjs";
 import { buildSitemap, buildRobots } from "./seo.mjs";
 import { loadAllDomains, loadAllProjectEntities, joinDomainProjects } from "./data-store.mjs";
 
@@ -253,7 +253,7 @@ for (const domain of parsedDomains) {
   });
 }
 
-// Today's-signals' "one to watch" and "heating up" need to compare
+// This-week's-signals' "one to watch" and "heating up" need to compare
 // percentDelta across every eligible project, not just the top
 // LEADERBOARD_LIMIT by score — a small, fast-growing project can rank well
 // outside the top 20 on score (which favors absolute gains) while still
@@ -261,14 +261,14 @@ for (const domain of parsedDomains) {
 // this repo's scale and keeps LEADERBOARD_LIMIT (the /rising/ page's own
 // per-section row count) untouched.
 const globalSignalsPool = computeLeaderboard(parsedDomains, { scope: "global", windowDays: TEASER_WINDOW_DAYS, limit: Infinity });
-const todaysSignals = pickTodaysSignals(globalSignalsPool);
+const thisWeeksSignals = pickThisWeeksSignals(globalSignalsPool);
 writeFileSync(
   `${DIST_DIR}/index.html`,
   renderLandingPage(domains, {
     defaultOgImage: DEFAULT_OG_IMAGE,
     siteUrl: SITE_URL,
     basePath: BASE_PATH,
-    signals: todaysSignals,
+    signals: thisWeeksSignals,
     momentumWindowDays: MOMENTUM_WINDOW_DAYS,
   })
 );

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -376,7 +376,7 @@ export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", baseP
         </a>`;
     })
     .join("");
-  const signalsSection = renderTodaysSignals(signals, { basePath });
+  const signalsSection = renderThisWeeksSignals(signals, { basePath });
   const websiteJsonLd = renderJsonLd(
     buildWebsiteJsonLd({
       name: "awesomemap",
@@ -488,7 +488,7 @@ function renderRisingTeaser(entries, { heading, href, showDomain, basePath }) {
 }
 
 /**
- * One card in the landing page's "Today's signals" module — same shape for
+ * One card in the landing page's "This week's signals" module — same shape for
  * every signal type, just a different label/title/stat/meta/href. The
  * navigable content lives in an inner `<a>` rather than making the whole
  * card a link, so the `compare-toggle` button (`compareId`, when the
@@ -514,13 +514,13 @@ function renderSignalCard({ label, title, stat, meta, href, compareId }) {
 }
 
 /**
- * Renders the landing page's "Today's signals" module — up to three cards
- * (biggest mover, heating-up project, one-to-watch) built from
- * `pickTodaysSignals`'s output (see todays-signals.mjs). Any signal that's
- * `null` (no qualifying candidate yet) is skipped; the whole section is
- * omitted when none qualify, rather than rendering an empty shell.
+ * Renders the landing page's "This week's signals" module — up to three
+ * cards (biggest mover, heating-up project, one-to-watch) built from
+ * `pickThisWeeksSignals`'s output (see this-weeks-signals.mjs). Any signal
+ * that's `null` (no qualifying candidate yet) is skipped; the whole section
+ * is omitted when none qualify, rather than rendering an empty shell.
  */
-function renderTodaysSignals({ mover, heatingUp, watch } = {}, { basePath }) {
+function renderThisWeeksSignals({ mover, heatingUp, watch } = {}, { basePath }) {
   const cards = [
     mover &&
       renderSignalCard({
@@ -554,8 +554,8 @@ function renderTodaysSignals({ mover, heatingUp, watch } = {}, { basePath }) {
   if (cards.length === 0) return "";
 
   return `
-    <section class="todays-signals">
-      <h2 class="todays-signals-heading">Today's signals</h2>
+    <section class="this-weeks-signals">
+      <h2 class="this-weeks-signals-heading">This week's signals</h2>
       <div class="signals-grid">${cards.join("")}</div>
     </section>`;
 }

--- a/scripts/this-weeks-signals.mjs
+++ b/scripts/this-weeks-signals.mjs
@@ -6,9 +6,9 @@
 export const SMALL_PROJECT_STAR_THRESHOLD = 5000;
 
 /**
- * Picks the landing page's three "today's signals" highlights — a reason
+ * Picks the landing page's three "this week's signals" highlights — a reason
  * to come back daily, per the homepage-hero backlog item's pairing with a
- * "today's signals" teaser. All three reuse data generate.mjs already
+ * "this week's signals" teaser. All three reuse data generate.mjs already
  * computes elsewhere; this module only selects, it does not derive new
  * growth math.
  *
@@ -19,13 +19,13 @@ export const SMALL_PROJECT_STAR_THRESHOLD = 5000;
  * before its `percentDelta` is ever compared for `watch`/`heatingUp`.
  *
  * Each of `mover`/`heatingUp`/`watch` is `null` when no candidate
- * qualifies (e.g. too early in the dataset's life) — `renderTodaysSignals`
+ * qualifies (e.g. too early in the dataset's life) — `renderThisWeeksSignals`
  * omits that card rather than rendering an empty one. `mover` and `watch`
  * are picked first so `heatingUp` can exclude their ids — otherwise it'd
  * often just repeat `watch` (percentage growth is usually won by small
  * projects).
  */
-export function pickTodaysSignals(moverPool, { starThreshold = SMALL_PROJECT_STAR_THRESHOLD } = {}) {
+export function pickThisWeeksSignals(moverPool, { starThreshold = SMALL_PROJECT_STAR_THRESHOLD } = {}) {
   const mover = pickBiggestMover(moverPool);
   const watch = pickOneToWatch(moverPool, starThreshold);
   const claimedIds = new Set([mover?.id, watch?.id].filter(Boolean));

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -435,16 +435,16 @@ test("renderLandingPage no longer renders the old global rising-teaser section",
   assert.doesNotMatch(html, /rising-teaser/);
 });
 
-test("renderLandingPage renders a today's-signals section between the hero and the map grid", () => {
+test("renderLandingPage renders a this-week's-signals section between the hero and the map grid", () => {
   const signals = {
     mover: { id: "a/a", name: "Project A", domainShort: "Data Science", starDelta: 400, percentDelta: 40 },
     heatingUp: { id: "c/c", name: "Project C", domainShort: "Data Science", percentDelta: 12 },
     watch: { id: "b/b", name: "Project B", domainShort: "Security", percentDelta: 80, currentStars: 900 },
   };
   const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], { defaultOgImage: "/og-default.png", signals });
-  assert.match(html, /<section class="todays-signals">/);
-  assert.ok(html.indexOf('class="hero"') < html.indexOf('class="todays-signals"'));
-  assert.ok(html.indexOf('class="todays-signals"') < html.indexOf('class="map-grid"'));
+  assert.match(html, /<section class="this-weeks-signals">/);
+  assert.ok(html.indexOf('class="hero"') < html.indexOf('class="this-weeks-signals"'));
+  assert.ok(html.indexOf('class="this-weeks-signals"') < html.indexOf('class="map-grid"'));
 });
 
 test("renderLandingPage's mover and watch signal cards link at the project's internal page, prefixed by BASE_PATH", () => {
@@ -484,17 +484,17 @@ test("renderLandingPage's heatingUp signal card links at that project's own inte
   assert.match(html, /<a class="signal-card-link" href="\/techmap\/projects\/c\/c\/">[\s\S]*?Project C[\s\S]*?<\/a>/);
 });
 
-test("renderLandingPage omits the today's-signals section entirely when no signal qualifies", () => {
+test("renderLandingPage omits the this-week's-signals section entirely when no signal qualifies", () => {
   const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], {
     defaultOgImage: "/og-default.png",
     signals: { mover: null, heatingUp: null, watch: null },
   });
-  assert.doesNotMatch(html, /todays-signals/);
+  assert.doesNotMatch(html, /this-weeks-signals/);
 });
 
-test("renderLandingPage defaults to no today's-signals section when the option is omitted entirely", () => {
+test("renderLandingPage defaults to no this-week's-signals section when the option is omitted entirely", () => {
   const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], { defaultOgImage: "/og-default.png" });
-  assert.doesNotMatch(html, /todays-signals/);
+  assert.doesNotMatch(html, /this-weeks-signals/);
 });
 
 test("renderLandingPage's hero includes a quick-jump link per domain, using its short name", () => {

--- a/test/this-weeks-signals.test.js
+++ b/test/this-weeks-signals.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { pickTodaysSignals, SMALL_PROJECT_STAR_THRESHOLD } from "../scripts/todays-signals.mjs";
+import { pickThisWeeksSignals, SMALL_PROJECT_STAR_THRESHOLD } from "../scripts/this-weeks-signals.mjs";
 
 /** Minimal leaderboard-candidate shape (a computeLeaderboard row). */
 function candidate(overrides) {
@@ -17,51 +17,51 @@ function candidate(overrides) {
   };
 }
 
-test("pickTodaysSignals' mover is the candidate with the largest absolute starDelta, not the highest score/rank", () => {
+test("pickThisWeeksSignals' mover is the candidate with the largest absolute starDelta, not the highest score/rank", () => {
   const pool = [
     candidate({ id: "big/big", starDelta: 500, currentStars: 50000 }),
     candidate({ id: "small/small", starDelta: 20, currentStars: 100 }),
   ];
-  const { mover } = pickTodaysSignals(pool);
+  const { mover } = pickThisWeeksSignals(pool);
   assert.equal(mover.id, "big/big");
 });
 
-test("pickTodaysSignals' mover is null when the pool is empty", () => {
-  const { mover } = pickTodaysSignals([]);
+test("pickThisWeeksSignals' mover is null when the pool is empty", () => {
+  const { mover } = pickThisWeeksSignals([]);
   assert.equal(mover, null);
 });
 
-test("pickTodaysSignals' watch is the highest-percentDelta candidate among those under the small-project star threshold", () => {
+test("pickThisWeeksSignals' watch is the highest-percentDelta candidate among those under the small-project star threshold", () => {
   const pool = [
     candidate({ id: "big/big", percentDelta: 300, currentStars: 50000 }), // too big to be "small"
     candidate({ id: "small-slow/small-slow", percentDelta: 10, currentStars: 200 }),
     candidate({ id: "small-fast/small-fast", percentDelta: 80, currentStars: 300 }),
   ];
-  const { watch } = pickTodaysSignals(pool);
+  const { watch } = pickThisWeeksSignals(pool);
   assert.equal(watch.id, "small-fast/small-fast");
 });
 
-test("pickTodaysSignals' watch is null when no candidate is under the star threshold", () => {
+test("pickThisWeeksSignals' watch is null when no candidate is under the star threshold", () => {
   const pool = [candidate({ id: "big/big", currentStars: SMALL_PROJECT_STAR_THRESHOLD + 1 })];
-  const { watch } = pickTodaysSignals(pool);
+  const { watch } = pickThisWeeksSignals(pool);
   assert.equal(watch, null);
 });
 
-test("pickTodaysSignals' heatingUp is the highest-percentDelta project in the pool", () => {
+test("pickThisWeeksSignals' heatingUp is the highest-percentDelta project in the pool", () => {
   const pool = [
     candidate({ id: "slow/slow", starDelta: 1, percentDelta: 2, currentStars: 9000 }),
     candidate({ id: "fast/fast", starDelta: 1, percentDelta: 40, currentStars: 8000 }),
   ];
-  const { heatingUp } = pickTodaysSignals(pool);
+  const { heatingUp } = pickThisWeeksSignals(pool);
   assert.equal(heatingUp.id, "fast/fast");
 });
 
-test("pickTodaysSignals' heatingUp is null when the pool is empty", () => {
-  const { heatingUp } = pickTodaysSignals([]);
+test("pickThisWeeksSignals' heatingUp is null when the pool is empty", () => {
+  const { heatingUp } = pickThisWeeksSignals([]);
   assert.equal(heatingUp, null);
 });
 
-test("pickTodaysSignals' heatingUp skips whichever candidate mover or watch already claimed", () => {
+test("pickThisWeeksSignals' heatingUp skips whichever candidate mover or watch already claimed", () => {
   const pool = [
     // Highest starDelta -> mover. Also has the highest percentDelta, so it
     // would win heatingUp too if heatingUp didn't exclude it.
@@ -71,7 +71,7 @@ test("pickTodaysSignals' heatingUp skips whichever candidate mover or watch alre
     // Next-highest percentDelta once mover and watch are excluded.
     candidate({ id: "heating/heating", starDelta: 10, percentDelta: 30, currentStars: 20000 }),
   ];
-  const { mover, watch, heatingUp } = pickTodaysSignals(pool);
+  const { mover, watch, heatingUp } = pickThisWeeksSignals(pool);
   assert.equal(mover.id, "mover/mover");
   assert.equal(watch.id, "watch/watch");
   assert.equal(heatingUp.id, "heating/heating");


### PR DESCRIPTION
Renames the homepage's "Today's signals" module to "This week's signals," matching its own card copy (e.g. "+643 stars (+0.4%) this week") and the README's "This week's biggest risers" language.

- `scripts/todays-signals.mjs` → `scripts/this-weeks-signals.mjs`
- `pickTodaysSignals` → `pickThisWeeksSignals`
- `renderTodaysSignals` → `renderThisWeeksSignals`
- `.todays-signals`/`.todays-signals-heading` → `.this-weeks-signals`/`.this-weeks-signals-heading`

First slice of `product.md`'s "site-wide copy pass toward heat/momentum language" item. MVP.md item 1, moved to `product.md`'s Shipped section and dropped from the shortlist; remaining items renumbered (also absorbing the separately-merged "Improve compare side-by-side" item's removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)