### PR TITLE
feat: domain filter and full-list link for This week's signals

### DIFF
--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -1026,10 +1026,53 @@ a.momentum-row-name:hover {
   letter-spacing: 0.04em;
 }
 
+.signals-domain-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 16px;
+}
+
+.signals-domain-button {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 4px 12px;
+  cursor: pointer;
+  color: var(--color-text);
+  font: inherit;
+  font-size: 12px;
+}
+
+.signals-domain-button-active {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+
+.signals-empty {
+  padding: 16px;
+  color: var(--color-text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
 .signals-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 16px;
+}
+
+.this-weeks-signals-link {
+  display: inline-block;
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.this-weeks-signals-link:hover {
+  text-decoration: underline;
 }
 
 .signal-card {

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -262,6 +262,17 @@ for (const domain of parsedDomains) {
 // per-section row count) untouched.
 const globalSignalsPool = computeLeaderboard(parsedDomains, { scope: "global", windowDays: TEASER_WINDOW_DAYS, limit: Infinity });
 const thisWeeksSignals = pickThisWeeksSignals(globalSignalsPool);
+
+// One more signals pick per domain, scoped the same uncapped way, so the
+// homepage's domain filter can swap to "just this domain's mover/heating
+// up/one to watch" without leaving the page — same show/hide-by-scope
+// pattern /rising/'s own domain filter already uses.
+const thisWeeksSignalsByDomain = {};
+for (const domain of parsedDomains) {
+  const domainSignalsPool = computeLeaderboard(parsedDomains, { scope: domain.slug, windowDays: TEASER_WINDOW_DAYS, limit: Infinity });
+  thisWeeksSignalsByDomain[domain.slug] = pickThisWeeksSignals(domainSignalsPool);
+}
+
 writeFileSync(
   `${DIST_DIR}/index.html`,
   renderLandingPage(domains, {
@@ -269,6 +280,7 @@ writeFileSync(
     siteUrl: SITE_URL,
     basePath: BASE_PATH,
     signals: thisWeeksSignals,
+    signalsByDomain: thisWeeksSignalsByDomain,
     momentumWindowDays: MOMENTUM_WINDOW_DAYS,
   })
 );

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -348,7 +348,10 @@ function renderDomainQuicklinks(domains, basePath) {
  * on an answer ("AI is moving fastest this week") instead of an alphabetical
  * index. Untracked domains sort last — see `rankGroups`.
  */
-export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", basePath = "", signals = {}, momentumWindowDays = RISING_WINDOWS_DAYS[0] }) {
+export function renderLandingPage(
+  domains,
+  { defaultOgImage, siteUrl = "", basePath = "", signals = {}, signalsByDomain = {}, momentumWindowDays = RISING_WINDOWS_DAYS[0] }
+) {
   const rankedDomains = rankGroups(
     domains.map((domain) => ({
       key: domain.slug,
@@ -376,7 +379,7 @@ export function renderLandingPage(domains, { defaultOgImage, siteUrl = "", baseP
         </a>`;
     })
     .join("");
-  const signalsSection = renderThisWeeksSignals(signals, { basePath });
+  const signalsSection = renderThisWeeksSignals(signals, { basePath, domains, signalsByDomain });
   const websiteJsonLd = renderJsonLd(
     buildWebsiteJsonLd({
       name: "awesomemap",
@@ -514,13 +517,15 @@ function renderSignalCard({ label, title, stat, meta, href, compareId }) {
 }
 
 /**
- * Renders the landing page's "This week's signals" module — up to three
- * cards (biggest mover, heating-up project, one-to-watch) built from
- * `pickThisWeeksSignals`'s output (see this-weeks-signals.mjs). Any signal
- * that's `null` (no qualifying candidate yet) is skipped; the whole section
- * is omitted when none qualify, rather than rendering an empty shell.
+ * Renders one scope's up to-three cards (biggest mover, heating-up project,
+ * one-to-watch) built from a `pickThisWeeksSignals` result — either the
+ * global pool or a single domain's. Any signal that's `null` (no qualifying
+ * candidate yet) is skipped. Falls back to the same not-enough-history
+ * message `renderRisingRows` uses, rather than rendering an empty grid, so
+ * switching the domain filter to a domain without enough history yet
+ * doesn't just leave blank space.
  */
-function renderThisWeeksSignals({ mover, heatingUp, watch } = {}, { basePath }) {
+function renderSignalCards({ mover, heatingUp, watch } = {}, { basePath }) {
   const cards = [
     mover &&
       renderSignalCard({
@@ -551,13 +556,76 @@ function renderThisWeeksSignals({ mover, heatingUp, watch } = {}, { basePath }) 
       }),
   ].filter(Boolean);
 
-  if (cards.length === 0) return "";
+  if (cards.length === 0) {
+    return `<p class="signals-empty">Not enough star-history yet for this window.</p>`;
+  }
+  return `<div class="signals-grid">${cards.join("")}</div>`;
+}
+
+/**
+ * Renders the landing page's "This week's signals" module: a domain filter
+ * bar (mirroring the one on `/rising/` — swapping which pre-rendered scope
+ * is visible client-side rather than navigating away), the global "All
+ * domains" cards plus one hidden card-set per domain from
+ * `signalsByDomain`, and a link to the full `/rising/` leaderboard. The
+ * whole section is omitted when neither the global scope nor any domain has
+ * a qualifying signal yet, rather than rendering an empty shell.
+ */
+function renderThisWeeksSignals(signals = {}, { basePath, domains = [], signalsByDomain = {} }) {
+  const hasSignal = (s) => Boolean(s?.mover || s?.heatingUp || s?.watch);
+  if (!hasSignal(signals) && !domains.some((domain) => hasSignal(signalsByDomain[domain.slug]))) return "";
+
+  const domainFilterBar =
+    domains.length > 0
+      ? `
+    <div class="signals-domain-filter" role="group" aria-label="Filter this week's signals by domain">
+      <button type="button" class="signals-domain-button signals-domain-button-active" data-domain="all">All</button>
+      ${domains
+        .map(
+          (domain) =>
+            `<button type="button" class="signals-domain-button" data-domain="${escapeHtml(domain.slug)}">${escapeHtml(domain.shortName ?? domain.name)}</button>`
+        )
+        .join("")}
+    </div>`
+      : "";
+
+  const scopes = [
+    `<div class="signals-scope" data-signals-scope="all">${renderSignalCards(signals, { basePath })}</div>`,
+    ...domains.map(
+      (domain) =>
+        `<div class="signals-scope" data-signals-scope="${escapeHtml(domain.slug)}" hidden>${renderSignalCards(signalsByDomain[domain.slug], { basePath })}</div>`
+    ),
+  ].join("");
+
+  // Same show/hide-by-id approach as /rising/'s domain filter (see
+  // renderRisingPage) — every scope is pre-rendered at build time, so
+  // switching domains never re-fetches or recomputes anything client-side.
+  const filterScript =
+    domains.length > 0
+      ? `
+    <script>
+      document.querySelectorAll(".signals-domain-filter button").forEach((button) => {
+        button.addEventListener("click", () => {
+          const selected = button.dataset.domain;
+          document.querySelectorAll(".signals-domain-filter button").forEach((b) => {
+            b.classList.toggle("signals-domain-button-active", b === button);
+          });
+          document.querySelectorAll(".this-weeks-signals [data-signals-scope]").forEach((el) => {
+            el.hidden = el.dataset.signalsScope !== selected;
+          });
+        });
+      });
+    </script>`
+      : "";
 
   return `
     <section class="this-weeks-signals">
       <h2 class="this-weeks-signals-heading">This week's signals</h2>
-      <div class="signals-grid">${cards.join("")}</div>
-    </section>`;
+      ${domainFilterBar}
+      ${scopes}
+      <a class="this-weeks-signals-link" href="${basePath}/rising/">See full leaderboard →</a>
+    </section>
+    ${filterScript}`;
 }
 
 /**

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -497,6 +497,68 @@ test("renderLandingPage defaults to no this-week's-signals section when the opti
   assert.doesNotMatch(html, /this-weeks-signals/);
 });
 
+test("renderLandingPage's this-week's-signals section links to the full /rising/ leaderboard, prefixed by BASE_PATH", () => {
+  const signals = { mover: { id: "a/a", name: "Project A", domainShort: "Data Science", starDelta: 400, percentDelta: 40 }, heatingUp: null, watch: null };
+  const html = renderLandingPage([{ slug: "data-science", name: "Data Science", description: "desc" }], {
+    defaultOgImage: "/og-default.png",
+    basePath: "/techmap",
+    signals,
+  });
+  assert.match(html, /<a class="this-weeks-signals-link" href="\/techmap\/rising\/">See full leaderboard →<\/a>/);
+});
+
+test("renderLandingPage's this-week's-signals section renders a domain filter bar, defaulting to \"All\" active and every domain's cards hidden", () => {
+  const signals = { mover: { id: "a/a", name: "Project A", domainShort: "Data Science", starDelta: 400, percentDelta: 40 }, heatingUp: null, watch: null };
+  const domains = [
+    { slug: "data-science", name: "Data Science", shortName: "Data Science", description: "desc" },
+    { slug: "security", name: "Security", shortName: "Security", description: "desc" },
+  ];
+  const html = renderLandingPage(domains, { defaultOgImage: "/og-default.png", signals });
+  assert.match(html, /<button type="button" class="signals-domain-button signals-domain-button-active" data-domain="all">All<\/button>/);
+  assert.match(html, /<button type="button" class="signals-domain-button" data-domain="data-science">Data Science<\/button>/);
+  assert.match(html, /<button type="button" class="signals-domain-button" data-domain="security">Security<\/button>/);
+  assert.match(html, /<div class="signals-scope" data-signals-scope="all">/);
+  assert.match(html, /<div class="signals-scope" data-signals-scope="data-science" hidden>/);
+  assert.match(html, /<div class="signals-scope" data-signals-scope="security" hidden>/);
+});
+
+test("renderLandingPage renders a domain's own this-week's-signals cards from signalsByDomain, inside that domain's hidden scope", () => {
+  const signals = { mover: null, heatingUp: null, watch: null };
+  const signalsByDomain = {
+    security: { mover: { id: "s/s", name: "Project S", domainShort: "Security", starDelta: 100, percentDelta: 10 }, heatingUp: null, watch: null },
+  };
+  const domains = [{ slug: "security", name: "Security", shortName: "Security", description: "desc" }];
+  const html = renderLandingPage(domains, { defaultOgImage: "/og-default.png", signals, signalsByDomain });
+  assert.match(html, /<div class="signals-scope" data-signals-scope="security" hidden>[\s\S]*?Project S[\s\S]*?<\/div>/);
+});
+
+test("renderLandingPage's this-week's-signals section falls back to a not-enough-history message for a domain scope with no qualifying signal", () => {
+  const signals = { mover: { id: "a/a", name: "Project A", domainShort: "Data Science", starDelta: 400, percentDelta: 40 }, heatingUp: null, watch: null };
+  const domains = [{ slug: "security", name: "Security", shortName: "Security", description: "desc" }];
+  const html = renderLandingPage(domains, { defaultOgImage: "/og-default.png", signals });
+  assert.match(html, /<div class="signals-scope" data-signals-scope="security" hidden><p class="signals-empty">Not enough star-history yet for this window\.<\/p><\/div>/);
+});
+
+test("renderLandingPage omits the domain filter bar and per-domain scopes when no domains are passed", () => {
+  const signals = { mover: { id: "a/a", name: "Project A", domainShort: "Data Science", starDelta: 400, percentDelta: 40 }, heatingUp: null, watch: null };
+  const html = renderLandingPage([], { defaultOgImage: "/og-default.png", signals });
+  assert.doesNotMatch(html, /signals-domain-filter/);
+  assert.match(html, /<a class="this-weeks-signals-link" href="\/rising\/">See full leaderboard →<\/a>/);
+});
+
+test("renderLandingPage still renders the this-week's-signals section when only a domain (not the global scope) has a qualifying signal", () => {
+  const signalsByDomain = {
+    security: { mover: { id: "s/s", name: "Project S", domainShort: "Security", starDelta: 100, percentDelta: 10 }, heatingUp: null, watch: null },
+  };
+  const domains = [{ slug: "security", name: "Security", shortName: "Security", description: "desc" }];
+  const html = renderLandingPage(domains, {
+    defaultOgImage: "/og-default.png",
+    signals: { mover: null, heatingUp: null, watch: null },
+    signalsByDomain,
+  });
+  assert.match(html, /<section class="this-weeks-signals">/);
+});
+
 test("renderLandingPage's hero includes a quick-jump link per domain, using its short name", () => {
   const domains = [
     { slug: "artificial-intelligence", name: "Best Artificial Intelligence Open Source Projects", shortName: "AI", description: "desc" },


### PR DESCRIPTION
## Summary
- Adds an "All"-plus-per-domain filter to the homepage's "This week's signals" module, so a visitor can narrow the mover/heating-up/one-to-watch cards to a single domain without leaving the homepage — reuses the same show/hide-by-id client-side pattern the `/rising/` page's own domain filter already uses.
- Adds a "See full leaderboard →" link below the cards, pointing at `/rising/`.

## Test plan
- `npm test` — 383/384 pass (the one failure, `test/layout.test.js`, is a pre-existing `node_modules` install issue unrelated to this change).
- `node scripts/generate.mjs` — verified the built `dist/index.html` renders the filter bar, all 9 hidden per-domain scopes, and the full-leaderboard link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)