### PR TITLE
fix: remove duplicate hero domain-quicklink strip

### DIFF
--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -467,30 +467,6 @@ body {
   line-height: 1.5;
 }
 
-.domain-quicklinks {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 8px;
-  margin: 20px 0 0;
-}
-
-.domain-quicklink {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  padding: 4px 12px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text);
-  text-decoration: none;
-}
-
-.domain-quicklink:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-}
-
 .map-index {
   box-sizing: border-box;
   max-width: 960px;

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -328,17 +328,6 @@ function renderTagWidget(topTags, risingTags, { basePath, windowDays, limit = 8 
     </section>`;
 }
 
-/** Renders a compact nav strip of short domain names, each jumping straight to that domain's filtered Rising leaderboard — a fast path for visitors who already know where they're headed, complementing the fuller `.map-grid` cards below. `domains` is `[{ slug, name, shortName }]`. */
-function renderDomainQuicklinks(domains, basePath) {
-  const links = domains
-    .map(
-      (domain) => `
-        <a class="domain-quicklink" href="${basePath}/rising/#${escapeHtml(domain.slug)}" title="${escapeHtml(domain.name)}">${escapeHtml(domain.shortName ?? domain.name)}</a>`
-    )
-    .join("");
-  return `<nav class="domain-quicklinks" aria-label="Jump to a domain">${links}</nav>`;
-}
-
 /**
  * Renders the landing page listing every domain. `domains` is an array of
  * { slug, name, shortName, description, growth } where `growth` is that
@@ -401,7 +390,6 @@ export function renderLandingPage(
       <div class="hero-content">
         <h1>awesomemap</h1>
         <p class="hero-tagline">What's taking off in open source — spotted by growth, not just stars.</p>
-        ${renderDomainQuicklinks(domains, basePath)}
       </div>
     </header>
     ${signalsSection}

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -559,18 +559,13 @@ test("renderLandingPage still renders the this-week's-signals section when only 
   assert.match(html, /<section class="this-weeks-signals">/);
 });
 
-test("renderLandingPage's hero includes a quick-jump link per domain, using its short name", () => {
+test("renderLandingPage's hero no longer duplicates a per-domain quick-jump strip now that this-week's-signals has its own domain filter", () => {
   const domains = [
     { slug: "artificial-intelligence", name: "Best Artificial Intelligence Open Source Projects", shortName: "AI", description: "desc" },
     { slug: "security", name: "Best Security Open Source Projects", shortName: "Security", description: "desc" },
   ];
   const html = renderLandingPage(domains, { defaultOgImage: "/og-default.png", basePath: "/techmap" });
-  assert.match(
-    html,
-    /<a class="domain-quicklink" href="\/techmap\/rising\/#artificial-intelligence" title="Best Artificial Intelligence Open Source Projects">AI<\/a>/
-  );
-  assert.match(html, /<a class="domain-quicklink" href="\/techmap\/rising\/#security" title="Best Security Open Source Projects">Security<\/a>/);
-  assert.ok(html.indexOf('class="domain-quicklinks"') < html.indexOf('class="map-grid"'));
+  assert.doesNotMatch(html, /domain-quicklink/);
 });
 
 test("every page type emits a plain meta description matching its og:description", () => {


### PR DESCRIPTION
## Summary
- The homepage hero had a per-domain quick-jump strip (linking to `/rising/#slug`) that now duplicates the domain filter built into the "This week's signals" module added in #40.
- Removes `renderDomainQuicklinks`, its call site in the hero, and its CSS — the signals module's own filter bar is now the homepage's only domain-filter UI.

## Test plan
- `npm test` — 383/384 pass (the one failure, `test/layout.test.js`, is a pre-existing `node_modules` install issue unrelated to this change).
- `node scripts/generate.mjs` — verified the built `dist/index.html` hero no longer has the quicklink strip, while the This week's signals filter bar is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)