### PR TITLE
feat: project search + fix mobile nav bar overflow

### DIFF
--- a/app/shared/search-match.js
+++ b/app/shared/search-match.js
@@ -1,0 +1,61 @@
+/**
+ * Pure matching/ranking for the /search/ page. Kept dependency- and
+ * DOM-free (mirrors compare-format.js's split from compare.js) so "does
+ * this project match this query, and how well" is unit-testable without a
+ * browser. `search.js` does the DOM wiring (fetching dist/compare-index.json
+ * — the same cross-domain project index the /compare/ page already ships —
+ * and calling rankProjects against it) and stays untested, per this repo's
+ * convention for DOM-mounting glue.
+ */
+
+/** Lowercases for case-insensitive matching; tolerates `null`/`undefined`. */
+function normalize(value) {
+  return (value ?? "").toLowerCase();
+}
+
+/**
+ * Scores one record against a already-normalized, non-empty `query`. Higher
+ * is a better match; `0` means "not a match at all". Name/id matches rank
+ * above tag matches, which rank above a description match — a query that
+ * merely appears in a project's prose shouldn't outrank one that's
+ * literally the project's name. An exact name/id match ranks highest of
+ * all, ahead of a mere prefix, so searching "react" surfaces `react` itself
+ * before `react-native` or `react-router`.
+ */
+function scoreRecord(record, query) {
+  const name = normalize(record.name);
+  const id = normalize(record.id);
+  const tags = (record.tags ?? []).map(normalize);
+  const desc = normalize(record.desc);
+
+  if (name === query || id === query) return 100;
+  if (name.startsWith(query)) return 90;
+  if (id.startsWith(query)) return 85;
+  if (tags.includes(query)) return 80;
+  if (name.includes(query)) return 70;
+  if (id.includes(query)) return 65;
+  if (tags.some((tag) => tag.includes(query))) return 50;
+  if (desc.includes(query)) return 30;
+  return 0;
+}
+
+/**
+ * Filters `records` (compare-index.json records, or anything with the same
+ * `name`/`id`/`tags`/`desc`/`weight` shape) to those matching `query`,
+ * ranked best-match-first (ties broken by star count, then name) — same
+ * "reuse what compare-index.json already computed" approach `compare.js`
+ * takes, just ranked instead of looked up by id. Returns `[]` for a blank
+ * query (a search page's "type to search" state, not "match everything" —
+ * the empty string is a substring of every record, which would otherwise
+ * make an empty box appear to match the whole index).
+ */
+export function rankProjects(records, query) {
+  const normalizedQuery = normalize(query).trim();
+  if (normalizedQuery === "") return [];
+
+  return records
+    .map((record) => ({ record, score: scoreRecord(record, normalizedQuery) }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score || (b.record.weight ?? 0) - (a.record.weight ?? 0) || a.record.name.localeCompare(b.record.name))
+    .map(({ record }) => record);
+}

--- a/app/shared/search.js
+++ b/app/shared/search.js
@@ -1,0 +1,172 @@
+// app/shared/search.js
+import { rankProjects } from "./search-match.js";
+import { formatStarCount } from "./star-history.js";
+import { refreshCompareButtons } from "./compare-cart.js";
+
+// How long to wait, after the last keystroke, before re-filtering and
+// updating the URL — filtering hundreds of records and touching
+// history.replaceState on every keystroke of a fast typist is wasted work
+// for intermediate states nobody ever sees.
+const FILTER_DEBOUNCE_MS = 150;
+
+/**
+ * Mounts the /search/ page into `container`. Fetches `searchIndexUrl`
+ * (dist/compare-index.json — the same cross-domain project index the
+ * /compare/ page already ships) once, then filters/ranks it client-side via
+ * `rankProjects` as the visitor types. `onQueryChange(query)` fires
+ * (debounced, see FILTER_DEBOUNCE_MS) whenever the query changes, so the
+ * caller can reflect it in the URL without this module touching
+ * `history`/`location` itself — the same split render-page.mjs's inline
+ * bootstrap script keeps for the treemap and /compare/ (see zoom-url.js,
+ * compare-url.js).
+ */
+export function mountSearch(container, { searchIndexUrl, basePath = "", initialQuery = "", onQueryChange }) {
+  const root = document.createElement("div");
+  root.className = "search-page";
+  container.appendChild(root);
+
+  const box = document.createElement("div");
+  box.className = "search-box";
+  const input = document.createElement("input");
+  input.type = "search";
+  input.className = "search-input";
+  input.placeholder = "Search by name, tag, or description…";
+  input.setAttribute("aria-label", "Search projects");
+  input.value = initialQuery;
+  box.appendChild(input);
+  root.appendChild(box);
+
+  const status = document.createElement("p");
+  status.className = "search-status";
+  status.setAttribute("role", "status");
+  root.appendChild(status);
+
+  const resultsEl = document.createElement("div");
+  root.appendChild(resultsEl);
+
+  let records = null;
+
+  const indexLoaded = fetch(searchIndexUrl)
+    .then((res) => (res.ok ? res.json() : Promise.reject(new Error(String(res.status)))))
+    .then((index) => {
+      records = Object.values(index);
+    })
+    .catch(() => {
+      status.textContent = "Couldn't load the project index. Please try reloading the page.";
+    });
+
+  indexLoaded.then(() => {
+    if (records) renderResults(input.value);
+  });
+
+  function renderResults(query) {
+    const trimmed = query.trim();
+
+    if (trimmed === "") {
+      status.textContent = records ? `Search across ${records.length.toLocaleString("en-US")} projects.` : "Loading…";
+      resultsEl.innerHTML = "";
+      return;
+    }
+
+    const matches = rankProjects(records, trimmed);
+    if (matches.length === 0) {
+      status.textContent = `No projects match "${trimmed}".`;
+      resultsEl.innerHTML = "";
+      const empty = document.createElement("div");
+      empty.className = "search-empty";
+      const link = document.createElement("a");
+      link.className = "search-empty-link";
+      link.href = `${basePath}/submit/`;
+      link.textContent = "Don't see it? Suggest a project →";
+      empty.appendChild(link);
+      resultsEl.appendChild(empty);
+      return;
+    }
+
+    status.textContent = `${matches.length.toLocaleString("en-US")} project${matches.length === 1 ? "" : "s"} match "${trimmed}".`;
+    resultsEl.innerHTML = "";
+    resultsEl.appendChild(renderRows(matches));
+    // Rows just entered the DOM with fresh + Compare buttons — sync their
+    // Added/not-added state to the cart (initCompareCartUI's own call ran
+    // before these existed).
+    refreshCompareButtons();
+  }
+
+  function renderRows(matches) {
+    const list = document.createElement("ol");
+    list.className = "search-rows-list";
+    for (const record of matches) list.appendChild(renderRow(record));
+    return list;
+  }
+
+  function renderRow(record) {
+    const li = document.createElement("li");
+    li.className = "search-row";
+
+    if (record.image) {
+      const icon = document.createElement("img");
+      icon.className = "search-row-icon";
+      icon.src = record.image;
+      icon.alt = "";
+      icon.loading = "lazy";
+      icon.onerror = () => icon.remove();
+      li.appendChild(icon);
+    }
+
+    const body = document.createElement("div");
+    body.className = "search-row-body";
+
+    const titleLine = document.createElement("div");
+    titleLine.className = "search-row-title-line";
+
+    const name = document.createElement("a");
+    name.className = "search-row-name";
+    name.href = `${basePath}/projects/${record.id}/`;
+    name.textContent = record.name;
+    titleLine.appendChild(name);
+
+    const domain = document.createElement("span");
+    domain.className = "search-row-domain";
+    domain.title = record.domainShort;
+    domain.textContent = record.domainShort;
+    titleLine.appendChild(domain);
+
+    const stars = document.createElement("span");
+    stars.className = "search-row-stars";
+    stars.textContent = `★ ${formatStarCount(record.weight) ?? "—"}`;
+    titleLine.appendChild(stars);
+
+    body.appendChild(titleLine);
+
+    if (record.desc) {
+      const desc = document.createElement("p");
+      desc.className = "search-row-desc";
+      desc.textContent = record.desc;
+      body.appendChild(desc);
+    }
+
+    li.appendChild(body);
+
+    const compareToggle = document.createElement("button");
+    compareToggle.type = "button";
+    compareToggle.className = "search-row-compare compare-toggle";
+    compareToggle.dataset.compareId = record.id;
+    compareToggle.setAttribute("aria-pressed", "false");
+    compareToggle.textContent = "+ Compare";
+    li.appendChild(compareToggle);
+
+    return li;
+  }
+
+  let debounceTimer = null;
+  input.addEventListener("input", () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      const query = input.value;
+      if (records) renderResults(query);
+      onQueryChange?.(query.trim());
+    }, FILTER_DEBOUNCE_MS);
+  });
+
+  if (initialQuery.trim() !== "") status.textContent = "Loading…";
+}

--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -41,6 +41,12 @@ body {
   font-family: system-ui, sans-serif;
   background: var(--color-bg);
   color: var(--color-text);
+  /* Safety net: no page section is meant to be wider than the viewport
+     (the treemap stage and every content column already cap their own
+     width). If one ever does overflow — as the unwrapped nav links did on
+     mobile — this stops it from turning into page-wide horizontal scroll
+     rather than papering over the section that overflowed. */
+  overflow-x: hidden;
 }
 
 .treemap-stage {
@@ -706,6 +712,15 @@ a.momentum-row-name:hover {
   gap: 10px;
 }
 
+.site-header-search {
+  display: flex;
+  color: var(--color-text-muted);
+}
+
+.site-header-search:hover {
+  color: var(--color-text);
+}
+
 .site-header-github {
   display: flex;
   color: var(--color-text-muted);
@@ -718,6 +733,29 @@ a.momentum-row-name:hover {
 .site-header-stars {
   display: block;
   border-radius: 3px;
+}
+
+/* Below this, the header's links (Search, Rising, Tags, Compare, Suggest a
+   project, GitHub, stars badge) no longer fit in one row — left unwrapped,
+   the row overflows its container and the whole page gains a horizontal
+   scrollbar, which reads as "the nav bar slides right" on a phone. Wrapping
+   the links onto as many rows as needed (instead of scrolling or clipping
+   them) keeps every link reachable without hiding navigation. */
+@media (max-width: 640px) {
+  .site-header {
+    flex-wrap: wrap;
+    row-gap: 8px;
+  }
+
+  .site-header-links {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  /* Decorative, not navigation — first to go when space is tight. */
+  .site-header-stars {
+    display: none;
+  }
 }
 
 .site-footer {
@@ -1391,4 +1429,139 @@ a.momentum-row-name:hover {
   font-size: 12px;
   color: var(--color-text-muted);
   margin: 12px 0 0;
+}
+
+/* /search/ page — a single search box over dist/compare-index.json (the
+   same cross-domain index /compare/ uses), rows styled after
+   .rising-row-list, with a star count in place of the rank/arrow/delta a
+   leaderboard row shows. */
+.search-app {
+  max-width: 700px;
+  margin: 0 auto 48px;
+  padding: 0 24px;
+}
+
+.search-box {
+  margin-bottom: 12px;
+}
+
+.search-input {
+  width: 100%;
+  box-sizing: border-box;
+  font: inherit;
+  color: inherit;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+
+.search-status {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.search-rows-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.search-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 13px;
+}
+
+.search-row:last-child {
+  border-bottom: none;
+}
+
+.search-row-icon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.search-row-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.search-row-title-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.search-row-name {
+  color: var(--color-accent);
+  text-decoration: none;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-row-domain {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  background: var(--color-accent-soft);
+  border-radius: 999px;
+  padding: 2px 8px;
+  max-width: 90px;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-row-stars {
+  flex-shrink: 0;
+  margin-left: auto;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.search-row-desc {
+  margin: 2px 0 0;
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-row-compare {
+  flex-shrink: 0;
+  font-size: 12px;
+  padding: 2px 10px;
+}
+
+@media (max-width: 480px) {
+  .search-row-compare {
+    display: none;
+  }
+}
+
+.search-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.search-empty-link {
+  color: var(--color-accent);
+  text-decoration: none;
+  font-weight: 600;
 }

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync, writeFileSync, mkdirSync, copyFileSync, rmSync, cpSync } from "node:fs";
 import { buildTree } from "./build-tree.mjs";
-import { renderDomainPage, renderLandingPage, renderRisingPage, renderTagsIndexPage, renderTagPage, renderProjectPage, renderComparePage, renderSubmitPage, tagSlug } from "./render-page.mjs";
+import { renderDomainPage, renderLandingPage, renderRisingPage, renderTagsIndexPage, renderTagPage, renderProjectPage, renderComparePage, renderSearchPage, renderSubmitPage, tagSlug } from "./render-page.mjs";
 import { buildCompareRecord, buildCompareIndex } from "./compare-index.mjs";
 import { explainSignal } from "./signal.mjs";
 import { sortedHistory } from "../app/shared/star-history.js";
@@ -410,6 +410,12 @@ writeFileSync(
   renderComparePage({ defaultOgImage: DEFAULT_OG_IMAGE, siteUrl: SITE_URL, basePath: BASE_PATH })
 );
 
+mkdirSync(`${DIST_DIR}/search`, { recursive: true });
+writeFileSync(
+  `${DIST_DIR}/search/index.html`,
+  renderSearchPage({ defaultOgImage: DEFAULT_OG_IMAGE, siteUrl: SITE_URL, basePath: BASE_PATH })
+);
+
 mkdirSync(`${DIST_DIR}/submit`, { recursive: true });
 writeFileSync(
   `${DIST_DIR}/submit/index.html`,
@@ -425,7 +431,7 @@ if (CNAME) writeFileSync(`${DIST_DIR}/CNAME`, `${CNAME}\n`);
 const sitemap = buildSitemap(domains.map((d) => d.slug), {
   siteUrl: SITE_URL,
   basePath: BASE_PATH,
-  extraPaths: ["/tags/", "/compare/", "/submit/", ...tagPagePaths, ...projectPagePaths],
+  extraPaths: ["/tags/", "/compare/", "/search/", "/submit/", ...tagPagePaths, ...projectPagePaths],
 });
 if (sitemap) writeFileSync(`${DIST_DIR}/sitemap.xml`, sitemap);
 writeFileSync(`${DIST_DIR}/robots.txt`, buildRobots({ siteUrl: SITE_URL, basePath: BASE_PATH }));

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -53,6 +53,12 @@ function renderSiteHeader(basePath) {
     <header class="site-header">
       <a class="site-header-brand" href="${basePath}/">awesomemap</a>
       <div class="site-header-links">
+        <a class="site-header-search" href="${basePath}/search/" aria-label="Search projects">
+          <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+            <path fill="none" stroke="currentColor" stroke-width="1.5" d="M11.5 6.75a4.75 4.75 0 1 1-9.5 0 4.75 4.75 0 0 1 9.5 0Z"/>
+            <path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M10.4 10.4 14 14"/>
+          </svg>
+        </a>
         <a class="site-header-rising" href="${basePath}/rising/">Rising</a>
         <a class="site-header-tags" href="${basePath}/tags/">Tags</a>
         <a class="site-header-compare" id="site-header-compare" href="${basePath}/compare/">Compare</a>
@@ -1150,6 +1156,52 @@ export function renderComparePage({ defaultOgImage, siteUrl = "", basePath = "" 
     title: "Compare projects — awesomemap",
     ogTitle: "Compare projects — awesomemap",
     ogDescription: "Compare stars, growth, and momentum across up to four open-source projects side by side.",
+    ogImage: defaultOgImage,
+    ogUrl,
+    base: basePath,
+    body,
+  });
+}
+
+/**
+ * Renders the /search/ page's static shell. Like /compare/, this shell
+ * carries no project data of its own — the actual filtering happens
+ * client-side (search.js) against dist/compare-index.json, the same
+ * cross-domain index /compare/ already ships, reused here rather than
+ * building a second one. Generic OG copy, since a static build can't know
+ * the query string in advance.
+ */
+export function renderSearchPage({ defaultOgImage, siteUrl = "", basePath = "" } = {}) {
+  const ogUrl = `${siteUrl}${basePath}/search/`;
+  const searchIndexUrl = `${basePath}/compare-index.json`;
+  const body = `
+    ${renderSiteHeader(basePath)}
+    ${renderCompareCartBootstrap(basePath)}
+    <header class="rising-hero">
+      <h1>Search projects</h1>
+      <p class="rising-hero-tagline">Find any project across every awesomemap domain by name, tag, or description.</p>
+    </header>
+    <div id="app" class="search-app"></div>
+    <script type="module">
+      import { mountSearch } from "${basePath}/shared/search.js";
+      const params = new URLSearchParams(location.search);
+      const initialQuery = params.get("q") ?? "";
+      mountSearch(document.getElementById("app"), {
+        searchIndexUrl: "${searchIndexUrl}",
+        basePath: "${basePath}",
+        initialQuery,
+        onQueryChange: (query) => {
+          const url = location.pathname + (query ? "?q=" + encodeURIComponent(query) : "");
+          history.replaceState(null, "", url);
+        },
+      });
+    </script>
+    ${renderSiteFooter()}
+  `;
+  return renderShell({
+    title: "Search projects — awesomemap",
+    ogTitle: "Search projects — awesomemap",
+    ogDescription: "Search every open-source project tracked across awesomemap's domains by name, tag, or description.",
     ogImage: defaultOgImage,
     ogUrl,
     base: basePath,

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -8,6 +8,7 @@ import {
   renderTagPage,
   renderProjectPage,
   renderComparePage,
+  renderSearchPage,
   renderSubmitPage,
   tagSlug,
 } from "../scripts/render-page.mjs";
@@ -1074,6 +1075,40 @@ test("renderComparePage renders a static heading and description before the moun
   assert.match(html, /<h1>Compare[^<]*<\/h1>/);
   assert.match(html, /<div id="app" class="compare-app">/);
   assert(html.indexOf("<h1>Compare") < html.indexOf('<div id="app" class="compare-app">'));
+});
+
+test("renderSearchPage mounts search.js against the compare index, prefixed by BASE_PATH", () => {
+  const html = renderSearchPage({ defaultOgImage: "/og-default.png", basePath: "/techmap" });
+  assert.match(html, /import \{ mountSearch \} from "\/techmap\/shared\/search.js"/);
+  assert.match(html, /searchIndexUrl: "\/techmap\/compare-index.json"/);
+  assert.match(html, /<div id="app" class="search-app"><\/div>/);
+});
+
+test("renderSearchPage has a site header and footer and a canonical /search/ URL", () => {
+  const html = renderSearchPage({ defaultOgImage: "/og-default.png", siteUrl: "https://awesomemap.dev", basePath: "" });
+  assert.match(html, /class="site-header"/);
+  assert.match(html, /class="site-footer"/);
+  assert.match(html, /href="https:\/\/awesomemap.dev\/search\/"/);
+});
+
+test("renderSearchPage defaults to root-relative paths when basePath is empty", () => {
+  const html = renderSearchPage({ defaultOgImage: "/og-default.png" });
+  assert.match(html, /from "\/shared\/search.js"/);
+  assert.match(html, /searchIndexUrl: "\/compare-index.json"/);
+});
+
+test("renderSearchPage renders a static heading before the mount point", () => {
+  const html = renderSearchPage({ defaultOgImage: "/og-default.png" });
+  assert.match(html, /<h1>Search projects<\/h1>/);
+  assert.match(html, /<div id="app" class="search-app">/);
+  assert(html.indexOf("<h1>Search projects") < html.indexOf('<div id="app" class="search-app">'));
+});
+
+test("renderSiteHeader (via renderSearchPage) links to /search/", () => {
+  const rootHtml = renderSearchPage({ defaultOgImage: "/og-default.png" });
+  assert.match(rootHtml, /class="site-header-search" href="\/search\/"/);
+  const prefixedHtml = renderSearchPage({ defaultOgImage: "/og-default.png", basePath: "/techmap" });
+  assert.match(prefixedHtml, /class="site-header-search" href="\/techmap\/search\/"/);
 });
 
 test("renderSubmitPage lists every domain's short name as a target-map option", () => {

--- a/test/search-match.test.js
+++ b/test/search-match.test.js
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rankProjects } from "../app/shared/search-match.js";
+
+const REACT = { id: "facebook/react", name: "React", tags: ["ui", "frontend"], desc: "A JS library for building UIs.", weight: 200000 };
+const REACT_NATIVE = { id: "facebook/react-native", name: "React Native", tags: ["mobile"], desc: "Build native apps with React.", weight: 100000 };
+const VUE = { id: "vuejs/vue", name: "Vue.js", tags: ["ui", "frontend"], desc: "The progressive JavaScript framework.", weight: 150000 };
+const RECORDS = [REACT, REACT_NATIVE, VUE];
+
+test("rankProjects returns [] for a blank query", () => {
+  assert.deepEqual(rankProjects(RECORDS, ""), []);
+  assert.deepEqual(rankProjects(RECORDS, "   "), []);
+});
+
+test("rankProjects is case-insensitive", () => {
+  const results = rankProjects(RECORDS, "REACT");
+  assert.deepEqual(results.map((r) => r.id), ["facebook/react", "facebook/react-native"]);
+});
+
+test("rankProjects ranks an exact name match above a prefix match", () => {
+  const results = rankProjects(RECORDS, "react");
+  assert.equal(results[0].id, "facebook/react");
+  assert.equal(results[1].id, "facebook/react-native");
+});
+
+test("rankProjects matches by tag", () => {
+  const results = rankProjects(RECORDS, "frontend");
+  assert.deepEqual(
+    results.map((r) => r.id).sort(),
+    ["facebook/react", "vuejs/vue"].sort(),
+  );
+});
+
+test("rankProjects matches by description when nothing else matches", () => {
+  const results = rankProjects(RECORDS, "progressive");
+  assert.deepEqual(results.map((r) => r.id), ["vuejs/vue"]);
+});
+
+test("rankProjects breaks ties between equally-ranked matches by star count", () => {
+  // Both have an exact "ui" tag, so both score the same — the tie is
+  // broken by weight (star count) descending.
+  const results = rankProjects([VUE, REACT], "ui");
+  assert.deepEqual(results.map((r) => r.id), ["facebook/react", "vuejs/vue"]);
+});
+
+test("rankProjects excludes non-matching records entirely", () => {
+  const results = rankProjects(RECORDS, "django");
+  assert.deepEqual(results, []);
+});


### PR DESCRIPTION
## Summary
- Adds a `/search/` page: a single search box that filters/ranks `dist/compare-index.json` client-side (name > tag > description match, ties broken by star count), reusing the same cross-domain index `/compare/` already ships. Zero matches links to `/submit/` ("Don't see it? Suggest a project").
- Adds a search icon to the site header on every page, linking to `/search/`.
- Fixes the nav bar overflowing horizontally on mobile: the links row didn't wrap, so it silently overflowed and made the whole page horizontally scrollable ("slides right"). The header's links now wrap below 640px (hiding only the decorative GitHub stars badge), plus a defensive `overflow-x: hidden` on `body`.

## New files
- `app/shared/search-match.js` — pure ranking logic, unit-tested.
- `app/shared/search.js` — DOM mounting glue (untested, matching this repo's convention for mounting code like `compare.js`).

## Testing
- `npm test` — 444/444 passing.
- Verified in a real headless-browser run: mobile nav no longer overflows (`scrollWidth > clientWidth` is false at 375px), `/search/` shows ranked results and the empty-state Suggest-a-project link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)