### PR TITLE
Project page repo stats + unified compare grid

### DIFF
--- a/app/shared/compare.js
+++ b/app/shared/compare.js
@@ -102,27 +102,57 @@ export function mountCompare(container, { compareIndexUrl, basePath = "", initia
     return index && Object.hasOwn(index, id) ? index[id] : null;
   }
 
+  /**
+   * Builds the whole comparison as a single CSS Grid — identity cards and
+   * stat rows share one `grid-template-columns`, so a project's header
+   * card sits directly above its own stat cells instead of the two
+   * living as visually separate components that merely happen to be the
+   * same width. Each "row" (header + one per STAT_ROWS entry) is a
+   * `display: contents` wrapper — invisible as a box, but its cells still
+   * flow into the shared grid in document order, the standard way to get
+   * real HTML-table-like rows (and their `role="row"` grouping for
+   * assistive tech) out of CSS Grid. See `.compare-grid` in treemap.css
+   * for the column template and the mobile carousel (scroll-snap) rules.
+   */
   function render() {
     root.innerHTML = "";
 
+    const showAddColumn = currentIds.length < MAX_COMPARE_IDS;
+    const columnCount = currentIds.length + (showAddColumn ? 1 : 0);
+    // Zero resolved records (e.g. every id in the URL is stale) means
+    // there's nothing to tabulate either — the header row's "not found"
+    // placeholders already say so, and a stats grid with only a label
+    // column would just be noise on top of that.
+    const hasStats = currentIds.some((id) => recordFor(id));
+
+    const wrap = document.createElement("div");
+    wrap.className = "compare-grid-wrap";
+
+    const grid = document.createElement("div");
+    grid.className = "compare-grid";
+    grid.style.setProperty("--compare-columns", columnCount);
+    grid.setAttribute("role", "table");
+    grid.setAttribute("aria-label", "Project comparison");
+
     const headerRow = document.createElement("div");
-    headerRow.className = "compare-grid";
+    headerRow.className = "compare-row compare-header-row";
+    headerRow.setAttribute("role", "row");
+    headerRow.appendChild(labelCell("", { role: "columnheader", spacer: true }));
     for (const id of currentIds) {
       const record = recordFor(id);
-      headerRow.appendChild(record ? renderHeaderCell(record) : renderNotFoundColumn(id));
+      headerRow.appendChild(record ? renderHeaderCell(record) : renderNotFoundCell(id));
     }
-    if (currentIds.length < MAX_COMPARE_IDS) {
-      headerRow.appendChild(renderAddColumn());
-    }
-    root.appendChild(headerRow);
+    if (showAddColumn) headerRow.appendChild(renderAddCell());
+    grid.appendChild(headerRow);
 
-    // Nothing to tabulate with zero resolved records (e.g. every id in the
-    // URL is stale) — the header row's "not found" placeholders already say
-    // so, a stats table with only a label column and no data would just be
-    // noise on top of that.
-    if (currentIds.some((id) => recordFor(id))) {
-      root.appendChild(renderStatsTable());
+    if (hasStats) {
+      for (const row of STAT_ROWS) {
+        grid.appendChild(renderStatRow(row, { showAddColumn }));
+      }
     }
+
+    wrap.appendChild(grid);
+    root.appendChild(wrap);
   }
 
   /** Builds the `{ [id]: winning }` map for one STAT_ROWS row: the set of ids tied for the row's best value, or `null` when the row has no `winnerValue` getter, fewer than two comparable values, or every comparable value ties. */
@@ -141,52 +171,53 @@ export function mountCompare(container, { compareIndexUrl, basePath = "", initia
   }
 
   /**
-   * The row-per-stat grid: one row per STAT_ROWS entry, one column per id in
-   * `currentIds` (a "—" cell for an id that didn't resolve, so columns stay
-   * aligned with the header row above), with the best value per row
-   * highlighted. Wrapped by the caller in a horizontally-scrollable
-   * container with a sticky label column, since up to 4 project columns
-   * plus an add column don't fit a narrow viewport.
+   * One stat row: a sticky label cell followed by one cell per id in
+   * `currentIds` (a "—" cell for an id that didn't resolve, so columns
+   * stay aligned with every other row), with the row's best value(s)
+   * highlighted. `display: contents` on the returned wrapper — see
+   * `render`'s doc comment — so these cells land in the same grid
+   * columns the header cards above already occupy.
    */
-  function renderStatsTable() {
-    const wrap = document.createElement("div");
-    wrap.className = "compare-table-wrap";
+  function renderStatRow(row, { showAddColumn }) {
+    const tr = document.createElement("div");
+    tr.className = "compare-row";
+    tr.setAttribute("role", "row");
+    const winners = row.winnerValue ? winnersForRow(row.winnerValue) : null;
 
-    const table = document.createElement("table");
-    table.className = "compare-table";
-    table.setAttribute("aria-label", "Stat-by-stat comparison");
+    tr.appendChild(labelCell(row.label, { role: "rowheader" }));
 
-    const tbody = document.createElement("tbody");
-    for (const row of STAT_ROWS) {
-      const tr = document.createElement("tr");
-      const winners = row.winnerValue ? winnersForRow(row.winnerValue) : null;
-
-      const th = document.createElement("th");
-      th.scope = "row";
-      th.className = "compare-row-label";
-      th.textContent = row.label;
-      tr.appendChild(th);
-
-      for (const id of currentIds) {
-        const record = recordFor(id);
-        const td = document.createElement("td");
-        if (record) {
-          td.textContent = row.cell(record);
-          if (winners?.has(id)) td.classList.add("compare-winner");
-        } else {
-          td.textContent = "—";
-          td.className = "compare-cell-empty";
-        }
-        tr.appendChild(td);
+    for (const id of currentIds) {
+      const record = recordFor(id);
+      const td = document.createElement("div");
+      td.className = "compare-cell";
+      td.setAttribute("role", "cell");
+      if (record) {
+        td.textContent = row.cell(record);
+        if (winners?.has(id)) td.classList.add("compare-winner");
+      } else {
+        td.textContent = "—";
+        td.classList.add("compare-cell-empty");
       }
-      if (currentIds.length < MAX_COMPARE_IDS) {
-        tr.appendChild(document.createElement("td")); // keeps this row under the add column, empty since it has nothing to add
-      }
-      tbody.appendChild(tr);
+      tr.appendChild(td);
     }
-    table.appendChild(tbody);
-    wrap.appendChild(table);
-    return wrap;
+    if (showAddColumn) {
+      // Keeps this row under the add column, empty since it has nothing to add.
+      const empty = document.createElement("div");
+      empty.className = "compare-cell";
+      empty.setAttribute("role", "cell");
+      tr.appendChild(empty);
+    }
+    return tr;
+  }
+
+  /** The grid's sticky left-hand label cell — a stat's name for a stat row, or an empty spacer reserving the same column's width in the header row (see `render`). */
+  function labelCell(text, { role, spacer = false }) {
+    const cell = document.createElement("div");
+    cell.className = "compare-cell compare-label-cell";
+    cell.setAttribute("role", role);
+    if (spacer) cell.classList.add("compare-label-spacer");
+    else cell.textContent = text;
+    return cell;
   }
 
   function removeButton(id) {
@@ -212,20 +243,22 @@ export function mountCompare(container, { compareIndexUrl, basePath = "", initia
     return button;
   }
 
-  function renderNotFoundColumn(id) {
-    const column = document.createElement("div");
-    column.className = "compare-column compare-column-missing";
-    column.appendChild(removeButton(id));
+  function renderNotFoundCell(id) {
+    const cell = document.createElement("div");
+    cell.className = "compare-cell compare-column compare-column-missing";
+    cell.setAttribute("role", "columnheader");
+    cell.appendChild(removeButton(id));
     const message = document.createElement("p");
     message.textContent = `"${id}" wasn't found.`;
-    column.appendChild(message);
-    return column;
+    cell.appendChild(message);
+    return cell;
   }
 
-  /** The header row's per-project card: identity (logo, name, domain, description, tags) and outbound links. Numeric stats live in the table below, not here — see STAT_ROWS. */
+  /** The header row's per-project cell: identity (logo, name, domain, description, tags) and outbound links. Numeric stats live in the rows below, not here — see STAT_ROWS. */
   function renderHeaderCell(record) {
     const column = document.createElement("div");
-    column.className = "compare-column";
+    column.className = "compare-cell compare-column";
+    column.setAttribute("role", "columnheader");
     column.appendChild(removeButton(record.id));
 
     if (record.image) {
@@ -281,9 +314,10 @@ export function mountCompare(container, { compareIndexUrl, basePath = "", initia
     return column;
   }
 
-  function renderAddColumn() {
+  function renderAddCell() {
     const column = document.createElement("div");
-    column.className = "compare-column compare-add-column";
+    column.className = "compare-cell compare-column compare-add-column";
+    column.setAttribute("role", "columnheader");
 
     const form = document.createElement("form");
     form.className = "compare-add-form";

--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -1217,6 +1217,47 @@ a.momentum-row-name:hover {
   text-align: center;
 }
 
+/* Stars/forks/open-issues, side by side — same repo-stat trio the /compare/
+   table's Stars/Forks/Open issues rows already surface, given a permanent
+   home on the project's own page rather than only showing up once it's
+   dropped into a comparison. */
+.project-repo-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.project-repo-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.project-repo-stat:hover {
+  border-color: var(--color-accent);
+}
+
+.project-repo-stat-value {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.project-repo-stat-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
 .project-links {
   margin-top: 16px;
   text-align: center;
@@ -1239,29 +1280,80 @@ a.momentum-row-name:hover {
   }
 }
 
-/* Compare page — up to 4 side-by-side project columns, all reusing
-   .detail-panel-* chip/link classes for visual consistency with the
-   detail panel and project pages. */
+/* Compare page — a single CSS Grid spanning both the per-project identity
+   cards and the stat-by-stat rows below them (see compare.js's `render`),
+   so the whole thing reads as one continuous comparison surface instead of
+   a row of cards sitting above an unrelated table. One shared
+   `--compare-columns` template keeps every row's cells aligned under the
+   header card they belong to. All reuses .detail-panel-* chip/link classes
+   for visual consistency with the detail panel and project pages. */
 .compare-app {
   max-width: 960px;
   margin: 24px auto 48px;
   padding: 0 24px;
 }
 
+/* The horizontally-scrollable frame around the grid: on a narrow viewport
+   this becomes a one-project-at-a-time carousel (native scroll-snap, no JS)
+   with the label column pinned at the left as you swipe through projects. */
+.compare-grid-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+  scroll-snap-type: x proximity;
+  scroll-padding-left: 180px; /* keeps a snapped column from sliding under the sticky label column */
+}
+
 .compare-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
-  align-items: start;
+  grid-template-columns: minmax(140px, 180px) repeat(var(--compare-columns), minmax(200px, 1fr));
+  min-width: fit-content;
+  font-size: 13px;
+}
+
+/* Each "row" is `display: contents` — invisible as a box, its cells simply
+   flow into the grid's columns in DOM order, the standard way to get real
+   table-like rows out of CSS Grid while keeping every column's width in
+   sync across the whole comparison. */
+.compare-row {
+  display: contents;
+}
+
+.compare-cell {
+  padding: 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.compare-row:last-child .compare-cell {
+  border-bottom: none;
+}
+
+.compare-header-row .compare-cell {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  border-bottom: 2px solid var(--color-border); /* a firmer line between identity and stats than the ones between stat rows */
+  scroll-snap-align: start; /* the header cell anchors its whole column's swipe position */
+}
+
+/* The sticky label column isn't a swipe target — it never moves — and
+   sticky positioning combined with scroll-snap-align has inconsistent
+   cross-browser behavior, so it's excluded rather than left to chance. */
+.compare-header-row .compare-label-spacer {
+  scroll-snap-align: none;
 }
 
 .compare-column {
   position: relative;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 16px;
   text-align: center;
+}
+
+/* Adjacent links (Visit site / View on GitHub) have no whitespace between
+   their DOM nodes (compare.js appends them directly), so with no gap
+   they'd butt up against each other on any line narrow enough to fit both
+   — most visible in the mobile carousel's narrower columns. */
+.compare-column .detail-panel-link + .detail-panel-link {
+  margin-left: 12px;
 }
 
 .compare-column-missing {
@@ -1270,8 +1362,8 @@ a.momentum-row-name:hover {
 
 .compare-remove {
   position: absolute;
-  top: 8px;
-  right: 8px;
+  top: 4px;
+  right: 4px;
   background: none;
   border: none;
   font-size: 18px;
@@ -1298,7 +1390,7 @@ a.momentum-row-name:hover {
 }
 
 .compare-add-column {
-  border-style: dashed;
+  border-left: 1px dashed var(--color-border);
 }
 
 .compare-add-form input {
@@ -1313,45 +1405,14 @@ a.momentum-row-name:hover {
   min-height: 1em;
 }
 
-/* Row-per-stat grid below the header cards: one row per stat (Stars, 7/30/
-   90d growth, Momentum, Forks, Open issues), one column per project, so
-   "who's winning on 30d growth" is a scan across a row instead of hunting
-   through stacked per-project cards. Horizontally scrollable rather than
-   reflowing to one-column-per-row on narrow viewports (compare.js's old
-   stacked-card layout did that) — a comparison table that drops its column
-   alignment on mobile stops being a comparison. */
-.compare-table-wrap {
-  margin-top: 16px;
-  overflow-x: auto;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  background: var(--color-surface);
-}
-
-.compare-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 13px;
-}
-
-.compare-table tr:not(:last-child) th,
-.compare-table tr:not(:last-child) td {
-  border-bottom: 1px solid var(--color-border);
-}
-
-.compare-table th,
-.compare-table td {
-  padding: 8px 12px;
-  text-align: left;
-  white-space: nowrap;
-}
-
-.compare-row-label {
+.compare-label-cell {
   position: sticky;
   left: 0;
+  z-index: 1;
   background: var(--color-surface);
   font-weight: 600;
   color: var(--color-text-muted);
+  white-space: nowrap;
 }
 
 .compare-cell-empty {
@@ -1364,9 +1425,23 @@ a.momentum-row-name:hover {
   font-weight: 600;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 640px) {
+  /* One project column roughly fills the viewport (minus the pinned label
+     column), so swiping horizontally pages through projects one at a time
+     — the "carousel" feel — while still peeking the next column's edge. */
+  .compare-grid-wrap {
+    scroll-padding-left: 96px;
+  }
+
   .compare-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 96px repeat(var(--compare-columns), minmax(78vw, 1fr));
+  }
+
+  .compare-label-cell {
+    font-size: 12px;
+    padding-left: 8px;
+    padding-right: 6px;
+    white-space: normal;
   }
 }
 

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -791,6 +791,11 @@ function formatStars(stars) {
   return Number(stars).toLocaleString("en-US");
 }
 
+/** Formats a plain repo count (forks, open issues) with thousands separators, or `"—"` when it isn't a finite number (no history snapshot captured it yet) — server-side counterpart to compare-format.js's client-side formatCount. */
+function formatCount(n) {
+  return typeof n === "number" && Number.isFinite(n) ? n.toLocaleString("en-US") : "—";
+}
+
 /** One row in the global "Top tags" list — star-ranked, no growth window involved. */
 function renderTopTagRow(entry, { basePath }) {
   const count = `${entry.projectCount} project${entry.projectCount === 1 ? "" : "s"}`;
@@ -1072,6 +1077,32 @@ export function renderProjectPage(
       </div>`
   ).join("");
 
+  // Forks/open-issue counts ride along on the latest history snapshot (see
+  // snapshot-history.mjs's buildSnapshotEntry) — same source
+  // compare-index.mjs's buildCompareRecord reads its own copy from, so a
+  // project with no history yet (and therefore no `latestSnapshot`) simply
+  // omits these two repo-stat chips rather than showing "—" placeholders.
+  const latestSnapshot = historySeries.length > 0 ? historySeries[historySeries.length - 1] : null;
+  const githubUrl = githubRepoUrl(project.id);
+  const repoStats = [
+    { label: "Stars", value: formatStars(project.weight ?? 0), href: githubUrl },
+    typeof latestSnapshot?.forks === "number"
+      ? { label: "Forks", value: formatCount(latestSnapshot.forks), href: `${githubUrl}/network/members` }
+      : null,
+    typeof latestSnapshot?.openIssues === "number"
+      ? { label: "Open issues", value: formatCount(latestSnapshot.openIssues), href: `${githubUrl}/issues` }
+      : null,
+  ].filter(Boolean);
+  const repoStatChips = repoStats
+    .map(
+      (stat) => `
+      <a class="project-repo-stat" href="${escapeHtml(stat.href)}" target="_blank" rel="noopener">
+        <span class="project-repo-stat-value">${stat.value}</span>
+        <span class="project-repo-stat-label">${stat.label}</span>
+      </a>`
+    )
+    .join("");
+
   const body = `
     ${renderSiteHeader(basePath)}
     ${renderCompareCartBootstrap(basePath)}
@@ -1086,8 +1117,9 @@ export function renderProjectPage(
     <div class="project-body">
       <div class="project-momentum-grid">${momentumChips}</div>
       ${renderProjectStarChart(historySeries)}
+      <div class="project-repo-stats">${repoStatChips}</div>
       <div class="project-links">
-        <a class="detail-panel-stars" href="${escapeHtml(githubRepoUrl(project.id))}" target="_blank" rel="noopener">★ ${formatStars(project.weight ?? 0)} stars on GitHub</a>
+        <a class="detail-panel-link" href="${escapeHtml(githubUrl)}" target="_blank" rel="noopener">View on GitHub ↗</a>
         ${project.link ? `<a class="detail-panel-link" href="${escapeHtml(project.link)}" target="_blank" rel="noopener">Visit site ↗</a>` : ""}
         <button type="button" class="detail-panel-link compare-toggle" data-compare-id="${escapeHtml(project.id)}" aria-pressed="false">+ Compare</button>
       </div>

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -997,6 +997,26 @@ test("renderProjectPage renders a star-history sparkline when given at least two
   assert.doesNotMatch(withoutHistory, /class="detail-panel-star-chart"/);
 });
 
+test("renderProjectPage renders forks/open-issues chips from the latest history snapshot, and omits them when it lacks that data", () => {
+  const withSnapshot = renderProjectPage(PROJECT, {
+    domain: PROJECT_DOMAIN,
+    signal: NO_SIGNAL,
+    defaultOgImage: "/og-default.png",
+    historySeries: [
+      { date: "2026-08-01", stars: 120000, forks: 17000, openIssues: 340 },
+      { date: "2026-08-08", stars: 125701, forks: 17420, openIssues: 356 },
+    ],
+  });
+  assert.match(withSnapshot, /class="project-repo-stat-value">17,420<\/span>\s*<span class="project-repo-stat-label">Forks/);
+  assert.match(withSnapshot, /class="project-repo-stat-value">356<\/span>\s*<span class="project-repo-stat-label">Open issues/);
+  assert.match(withSnapshot, /href="https:\/\/github\.com\/ggerganov\/llama\.cpp\/network\/members"/);
+  assert.match(withSnapshot, /href="https:\/\/github\.com\/ggerganov\/llama\.cpp\/issues"/);
+
+  const withoutSnapshot = renderProjectPage(PROJECT, { domain: PROJECT_DOMAIN, signal: NO_SIGNAL, defaultOgImage: "/og-default.png" });
+  assert.doesNotMatch(withoutSnapshot, /Forks/);
+  assert.doesNotMatch(withoutSnapshot, /Open issues/);
+});
+
 test("renderProjectPage degrades gracefully for a minimal project record with only an id", () => {
   const minimal = { id: "a/b" };
   const html = renderProjectPage(minimal, { domain: PROJECT_DOMAIN, signal: NO_SIGNAL, defaultOgImage: "/og-default.png", basePath: "" });


### PR DESCRIPTION
## Summary
- Project page: adds Stars/Forks/Open issues stat chips, sourced from the latest history snapshot (same data compare-index.mjs already surfaces), each linking to the matching GitHub page (repo, forks, issues).
- Compare page: unifies the per-project header cards and the stat-by-stat table into a single CSS Grid so they read as one continuous surface (columns stay pixel-aligned across both sections), instead of two visually disconnected components. Adds scroll-snap so mobile gets a one-project-at-a-time carousel with the stat labels pinned on the left.

## Testing
- `npm test` — 445 passed
- `npm run generate` — builds cleanly
- Manually verified in a headless browser: project page repo-stat chips (light/dark), compare page grid alignment (light/dark, desktop), the mobile carousel snap behavior, and the "project not found" column's cells stay aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)