### PR TITLE
feat: external event timeline on the project page

### DIFF
--- a/.github/workflows/snapshot-history.yml
+++ b/.github/workflows/snapshot-history.yml
@@ -24,6 +24,7 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: node scripts/snapshot-history.mjs
+      - run: node scripts/snapshot-events.mjs
       - run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/MVP.md
+++ b/MVP.md
@@ -22,13 +22,3 @@ Shipped section and drop it from here rather than checking it off in place.
    week") using math the codebase already has, surfaced on the homepage
    alongside "This week's signals," so a visitor can answer "what's hot"
    at the ecosystem level, not just the single-project level.
-
-3. **[ ] Project page: add forks, issues, etc.** `buildSnapshotEntry`
-   (`scripts/snapshot-history.mjs`) already captures `forks` and
-   `openIssues` in every daily snapshot, and the compare view already
-   displays them (`compare.js`'s "Forks"/"Open issues" stat rows) — but
-   `renderProjectPage` itself, the canonical per-project page, still only
-   shows star count and momentum chips. Add the same forks/open-issues
-   stats (and any other already-captured-but-unsurfaced fields, e.g.
-   GitHub's own name/description for drift detection) to the project page,
-   reusing `compare-format.js`'s `formatCount` rather than a new formatter.

--- a/MVP.md
+++ b/MVP.md
@@ -22,3 +22,4 @@ Shipped section and drop it from here rather than checking it off in place.
    week") using math the codebase already has, surfaced on the homepage
    alongside "This week's signals," so a visitor can answer "what's hot"
    at the ecosystem level, not just the single-project level.
+

--- a/app/shared/star-history.js
+++ b/app/shared/star-history.js
@@ -97,6 +97,20 @@ function formatShortDate(dateStr) {
   );
 }
 
+/**
+ * Formats a date with its year (e.g. "Aug 8, 2025"), unlike `formatShortDate`'s
+ * month/day-only — for the project page's events timeline (see
+ * scripts/render-page.mjs's `renderProjectEventsTimeline`), where an entry
+ * can be years old (`events` is never pruned, unlike `history`'s 120-day
+ * window `formatShortDate`'s callers stay implicitly within), so the year
+ * can't be left implied.
+ */
+export function formatEventDate(dateStr) {
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" }).format(
+    new Date(`${dateStr}T00:00:00Z`)
+  );
+}
+
 function round(n) {
   return Math.round(n * 100) / 100;
 }

--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -1258,6 +1258,73 @@ a.momentum-row-name:hover {
   letter-spacing: 0.06em;
 }
 
+/* Chronological HN/release timeline — the "why did this grow" companion
+   to the star-history sparkline above it (renderProjectEventsTimeline,
+   scripts/render-page.mjs). */
+.project-events {
+  margin-top: 20px;
+}
+
+.project-events-heading {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 8px;
+}
+
+.project-events-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.project-event {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
+
+.project-event-type {
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.project-event-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.project-event-title:hover {
+  text-decoration: underline;
+}
+
+.project-event-date,
+.project-event-points {
+  flex: 0 0 auto;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
 .project-links {
   margin-top: 16px;
   text-align: center;

--- a/product.md
+++ b/product.md
@@ -181,6 +181,20 @@ net if the daily jobs that feed it go quiet.
       re-accumulates, or hand-editing history files. A script to
       recompute/re-derive stored history would make future formula
       changes safe to ship.
+- [ ] LLM-based "is this interesting" classification for the project-page
+      event timeline (see MVP.md). v1 gates GitHub releases only on
+      non-prerelease and HN stories only on a points threshold — both
+      free and deterministic, but a release's actual notability (a patch
+      that ships a critical CVE fix vs. a routine dependency bump) is a
+      real semantic judgment a fixed rule can't make well. The codebase
+      already has the pattern for this: `scripts/classify-candidates.mjs`
+      calls an LLM (OpenRouter, `google/gemini-3.7-flash`) with a
+      structured tool-call response (`fits`/`confidence`/`reason`) and a
+      safe fallback on an unparseable response. A future
+      `classify-events.mjs` could reuse that shape for release bodies —
+      biased toward "show it" on any classification failure, so a parsing
+      hiccup never silently drops a real event.
+
 ## Measurement
 
 - [ ] Add privacy-friendly analytics (e.g. Plausible, GoatCounter, Umami —
@@ -201,6 +215,25 @@ net if the daily jobs that feed it go quiet.
 
 ## Shipped
 
+- [x] External event timeline on the canonical project page. The
+      star-history sparkline (`renderProjectPage`,
+      `scripts/render-page.mjs`) showed *that* a project grew, never *why*.
+      A new daily job (`scripts/snapshot-events.mjs`, one added step in
+      `.github/workflows/snapshot-history.yml`, same commit as the star
+      snapshot) fetches HN stories whose URL matches the repo (Algolia HN
+      Search API, restricted to the `url` field with a strict post-filter
+      against tokenized false positives, kept only at ≥50 points) and
+      non-draft/non-prerelease GitHub releases (same `gh`-token API the
+      star snapshot already calls), merging both into a new `events` array
+      per project entity — unlike `history`, never pruned, since events
+      are sparse enough that the full timeline is worth keeping.
+      `renderProjectPage` now renders it as a "Timeline" list, newest-first,
+      capped to the most recent 20 entries, right below the repo stats.
+      No LLM-based "is this interesting" classification for v1 (see Data
+      foundation below for that as a future refinement) — HN's own points
+      and "non-prerelease" are free, deterministic proxies instead.
+      _Done 2026-09-02: MVP item 3 ("External event timeline on the
+      project page")._
 - [x] Forks/open-issues stats on the canonical project page.
       `buildSnapshotEntry` (`scripts/snapshot-history.mjs`) captures
       `forks`/`openIssues` in every daily snapshot, and the `/compare/`

--- a/product.md
+++ b/product.md
@@ -201,6 +201,18 @@ net if the daily jobs that feed it go quiet.
 
 ## Shipped
 
+- [x] Forks/open-issues stats on the canonical project page.
+      `buildSnapshotEntry` (`scripts/snapshot-history.mjs`) captures
+      `forks`/`openIssues` in every daily snapshot, and the `/compare/`
+      table already displayed them — but `renderProjectPage` itself only
+      showed star count and momentum chips. It now renders the same two
+      stats as `.project-repo-stats` chips, sourced from the latest
+      history snapshot and formatted with `compare-format.js`'s
+      `formatCount` (the same formatter, not a new one), linking out to
+      the repo's GitHub network/issues pages. The compare page's stat
+      grid was unified into one aligned table in the same change.
+      _Done 2026-09-02: MVP item 3 ("Project page: add forks, issues,
+      etc.")._
 - [x] Row-per-stat compare grid with a winner highlight.
       `app/shared/compare.js`'s `/compare/` table used to render one full
       vertical stat card per project as sibling columns — Stars/7d/30d/90d

--- a/scripts/data-store.mjs
+++ b/scripts/data-store.mjs
@@ -8,7 +8,7 @@
 //   data/projects/<owner>/<repo>.json — one file per project entity:
 //                                       {schemaVersion, id, link, name, desc,
 //                                       githubName, githubDescription,
-//                                       weight, image, tags, history}
+//                                       weight, image, tags, history, events}
 //
 // Every script that used to read/write `data/<slug>.json` +
 // `data/history/<slug>.json` directly goes through this module instead, so

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -5,6 +5,7 @@ import { renderDomainPage, renderLandingPage, renderRisingPage, renderTagsIndexP
 import { buildCompareRecord, buildCompareIndex } from "./compare-index.mjs";
 import { explainSignal } from "./signal.mjs";
 import { sortedHistory } from "../app/shared/star-history.js";
+import { sortedEvents } from "./project-events.mjs";
 import { computeProjectSizing, findInvalidSizes, RISING_WINDOWS_DAYS } from "./velocity.mjs";
 import { computeLeaderboard } from "./leaderboard.mjs";
 import { computeGroupGrowth, rankGroups } from "./group-growth.mjs";
@@ -378,6 +379,7 @@ for (const project of allProjectsWithDomain) {
     categoryName: categoryEntry?.key,
   });
   const historySeries = sortedHistory(project.history);
+  const eventsSeries = sortedEvents(project.events);
   compareRecords.push(buildCompareRecord(project, { historySeries, signalHeadline: signal.headline }));
 
   // `allProjectsWithDomain` already carries `domainSlug`/`domainShort`
@@ -391,6 +393,7 @@ for (const project of allProjectsWithDomain) {
       domain: { slug: project.domainSlug, shortName: project.domainShort },
       signal,
       historySeries,
+      eventsSeries,
       defaultOgImage: DEFAULT_OG_IMAGE,
       siteUrl: SITE_URL,
       basePath: BASE_PATH,

--- a/scripts/project-events.mjs
+++ b/scripts/project-events.mjs
@@ -1,0 +1,20 @@
+/**
+ * Pure helper for the project page's external-events timeline (MVP.md:
+ * "External event timeline on the project page"). Kept dependency-free and
+ * build-only — mirrors `app/shared/star-history.js`'s `sortedHistory` split
+ * for the sibling `events` array on the same project entity (see
+ * `data-store.mjs`), but lives under `scripts/` rather than `app/shared/`
+ * since nothing client-side renders events yet.
+ */
+
+/**
+ * Sorts a project entity's own `events` array oldest-first — the
+ * build-time equivalent of `star-history.js`'s `sortedHistory`, for the
+ * `events` array `scripts/snapshot-events.mjs` populates instead of
+ * `history`. Returns `[]` for anything that isn't a real array (a project
+ * with no recorded events yet).
+ */
+export function sortedEvents(events) {
+  if (!Array.isArray(events)) return [];
+  return [...events].sort((a, b) => a.date.localeCompare(b.date));
+}

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { RISING_WINDOWS_DAYS } from "./velocity.mjs";
 import { rankGroups } from "./group-growth.mjs";
 import { buildWebsiteJsonLd, buildItemListJsonLd, buildSoftwareSourceCodeJsonLd } from "./seo.mjs";
-import { githubRepoUrl, buildSparklinePath, starHistoryCaption } from "../app/shared/star-history.js";
+import { githubRepoUrl, buildSparklinePath, starHistoryCaption, formatEventDate } from "../app/shared/star-history.js";
 
 const TEMPLATE = readFileSync(new URL("../app/index.html.template", import.meta.url), "utf8");
 
@@ -1044,6 +1044,48 @@ function renderProjectTagChips(tags, basePath) {
   return `<div class="detail-panel-tags">${chips}</div>`;
 }
 
+const EVENTS_TIMELINE_LIMIT = 20;
+const EVENT_TYPE_LABELS = { hn: "HN", release: "Release" };
+
+/**
+ * Server-rendered chronological timeline of external events (HN
+ * discussions, GitHub releases) for a project page — the "why did this
+ * grow" companion to the star-history sparkline above it. `eventsSeries`
+ * is `project-events.mjs`'s `sortedEvents` output (oldest-first, mirroring
+ * `historySeries`'s convention); rendered newest-first here, like a
+ * changelog, and capped to the most recent `EVENTS_TIMELINE_LIMIT` — only
+ * the rendered slice is capped, `events` itself is never pruned (see
+ * scripts/snapshot-events.mjs). Renders nothing for a project with no
+ * recorded events yet, same "nothing to show" convention as
+ * `renderProjectStarChart`.
+ */
+function renderProjectEventsTimeline(eventsSeries) {
+  if (!Array.isArray(eventsSeries) || eventsSeries.length === 0) return "";
+  const rows = [...eventsSeries]
+    .reverse()
+    .slice(0, EVENTS_TIMELINE_LIMIT)
+    .map((event) => {
+      const label = EVENT_TYPE_LABELS[event.type] ?? event.type;
+      const points =
+        typeof event.points === "number"
+          ? `<span class="project-event-points">${formatCount(event.points)} pts</span>`
+          : "";
+      return `
+      <li class="project-event">
+        <span class="project-event-type project-event-type-${escapeHtml(event.type)}">${escapeHtml(label)}</span>
+        <a class="project-event-title" href="${escapeHtml(event.url)}" target="_blank" rel="noopener">${escapeHtml(event.title)}</a>
+        <span class="project-event-date">${escapeHtml(formatEventDate(event.date))}</span>
+        ${points}
+      </li>`;
+    })
+    .join("");
+  return `
+    <div class="project-events">
+      <h2 class="project-events-heading">Timeline</h2>
+      <ul class="project-events-list">${rows}</ul>
+    </div>`;
+}
+
 /**
  * Renders one project's canonical page — the shareable, indexable home for
  * a project that today only exists as ephemeral detail-panel state inside
@@ -1057,7 +1099,7 @@ function renderProjectTagChips(tags, basePath) {
  */
 export function renderProjectPage(
   project,
-  { domain, signal = {}, historySeries = [], defaultOgImage, siteUrl = "", basePath = "" }
+  { domain, signal = {}, historySeries = [], eventsSeries = [], defaultOgImage, siteUrl = "", basePath = "" }
 ) {
   const ogUrl = `${siteUrl}${basePath}/projects/${project.id}/`;
   const jsonLd = renderJsonLd(
@@ -1118,6 +1160,7 @@ export function renderProjectPage(
       <div class="project-momentum-grid">${momentumChips}</div>
       ${renderProjectStarChart(historySeries)}
       <div class="project-repo-stats">${repoStatChips}</div>
+      ${renderProjectEventsTimeline(eventsSeries)}
       <div class="project-links">
         <a class="detail-panel-link" href="${escapeHtml(githubUrl)}" target="_blank" rel="noopener">View on GitHub ↗</a>
         ${project.link ? `<a class="detail-panel-link" href="${escapeHtml(project.link)}" target="_blank" rel="noopener">Visit site ↗</a>` : ""}

--- a/scripts/snapshot-events.mjs
+++ b/scripts/snapshot-events.mjs
@@ -1,0 +1,167 @@
+// Daily job (added as a step in .github/workflows/snapshot-history.yml,
+// same commit as the star snapshot) that fetches external "why did this
+// grow" events for every project entity and appends them to a new `events`
+// array, alongside `history` (see data-store.mjs). Two free, deterministic
+// sources for v1 — no LLM classification (see product.md's Data
+// foundation section for that as a future refinement):
+//
+//   - HN discussions whose submitted url points at the repo (Algolia HN
+//     Search API, unauthenticated), kept only above a points threshold.
+//   - Non-draft, non-prerelease GitHub releases (same gh-token API
+//     snapshot-history.mjs already calls, no extra credential needed).
+//
+// Unlike `history`, `events` is never pruned — events are sparse enough
+// (a handful a year even for an active repo) that the full timeline is
+// worth keeping; scripts/render-page.mjs caps the *rendered* slice
+// instead.
+import { execFileSync } from "node:child_process";
+import { parseGhRepo, createGetJson, withRetry } from "./enrich-domain.mjs";
+import { loadAllProjectEntities, saveProjectEntity } from "./data-store.mjs";
+
+const HN_POINTS_THRESHOLD = 50;
+const HN_SEARCH_URL = "https://hn.algolia.com/api/v1/search";
+
+/** Builds the Algolia HN search URL for stories whose url field matches this repo. */
+export function buildHnSearchUrl(owner, repo) {
+  const params = new URLSearchParams({
+    query: `${owner}/${repo}`,
+    restrictSearchableAttributes: "url",
+    tags: "story",
+    hitsPerPage: "50",
+  });
+  return `${HN_SEARCH_URL}?${params.toString()}`;
+}
+
+/**
+ * True when an Algolia HN search hit's own url actually points at this
+ * repo. Algolia's `restrictSearchableAttributes=url` search is tokenized,
+ * not an exact match — querying "facebook/react" can surface a story about
+ * an unrelated, similarly-named repo. This is the precision backstop: only
+ * a hit whose url contains `github.com/<owner>/<repo>` survives.
+ */
+export function hnHitMatchesRepo(hit, owner, repo) {
+  const url = typeof hit?.url === "string" ? hit.url.toLowerCase() : "";
+  return url.includes(`github.com/${owner}/${repo}`.toLowerCase());
+}
+
+/**
+ * Maps one Algolia HN search hit onto an event entry — the event links to
+ * the HN discussion itself (not back to the repo the reader is already
+ * on). `created_at` is a full ISO timestamp; only the date portion is
+ * kept, matching every other event/history entry's `date` shape.
+ */
+export function mapHnHit(hit) {
+  return {
+    date: hit.created_at.slice(0, 10),
+    type: "hn",
+    title: hit.title,
+    url: `https://news.ycombinator.com/item?id=${hit.objectID}`,
+    points: hit.points,
+  };
+}
+
+/**
+ * Fetches this repo's HN mentions, filtered to real url matches (see
+ * `hnHitMatchesRepo`) at or above `pointsThreshold`, mapped to event
+ * entries. `fetchImpl` is injectable for testing, same convention as
+ * `enrich-domain.mjs`'s `createGetJson`.
+ */
+export async function fetchHnEvents(owner, repo, { fetchImpl = fetch, pointsThreshold = HN_POINTS_THRESHOLD } = {}) {
+  const data = await withRetry(async () => {
+    const res = await fetchImpl(buildHnSearchUrl(owner, repo));
+    if (!res.ok) {
+      const err = new Error(`${res.status} ${res.statusText} for HN search of ${owner}/${repo}`);
+      err.status = res.status;
+      throw err;
+    }
+    return res.json();
+  });
+  const hits = Array.isArray(data?.hits) ? data.hits : [];
+  return hits
+    .filter((hit) => hnHitMatchesRepo(hit, owner, repo) && typeof hit.points === "number" && hit.points >= pointsThreshold)
+    .map(mapHnHit);
+}
+
+/** True for a real, publicly-visible release — excludes drafts (not yet published) and prereleases (not a "launch"). */
+export function isPublishedRelease(release) {
+  return release?.draft !== true && release?.prerelease !== true;
+}
+
+/** Maps one GitHub release onto an event entry, preferring the release's own name over its bare tag. */
+export function mapRelease(release) {
+  return {
+    date: (release.published_at ?? release.created_at).slice(0, 10),
+    type: "release",
+    title: release.name || release.tag_name,
+    url: release.html_url,
+    points: null,
+  };
+}
+
+/** Fetches this repo's published (non-draft, non-prerelease) releases, mapped to event entries. `getJson` is the gh-token-authenticated fetcher from `enrich-domain.mjs`'s `createGetJson`. */
+export async function fetchReleaseEvents(owner, repo, getJson) {
+  const releases = await getJson(`https://api.github.com/repos/${owner}/${repo}/releases`);
+  return (Array.isArray(releases) ? releases : []).filter(isPublishedRelease).map(mapRelease);
+}
+
+/**
+ * Merges newly-fetched events into a project's existing `events` array,
+ * deduped by `url` (an event's natural identity — an HN thread or a
+ * release has exactly one URL), sorted ascending by date. A url shared
+ * with an existing entry is replaced rather than duplicated — the same
+ * "re-running is a no-op / re-running picks up fresh data" property
+ * `snapshot-history.mjs`'s `appendSnapshotEntry` has for `history`, and
+ * additionally lets a re-fetched HN entry's `points` climb as a thread
+ * gains votes instead of staying frozen at first-seen.
+ */
+export function appendEventEntries(existing, newEvents) {
+  const byUrl = new Map();
+  for (const event of existing ?? []) byUrl.set(event.url, event);
+  for (const event of newEvents) byUrl.set(event.url, event);
+  return [...byUrl.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+// CLI entry point: node scripts/snapshot-events.mjs
+// Snapshots every project entity in data/projects/**/*.json, merging fresh
+// HN + release events into its `events` array. Thin I/O orchestration, not
+// unit tested (same convention as snapshot-history.mjs's main()) —
+// verified manually.
+async function main() {
+  const token = execFileSync("gh", ["auth", "token"], { encoding: "utf8" }).trim();
+  const getJson = createGetJson(token);
+  const entitiesById = loadAllProjectEntities();
+
+  let totalAttempted = 0;
+  let totalFetched = 0;
+  let failed = 0;
+
+  for (const entity of entitiesById.values()) {
+    const repo = parseGhRepo(entity.id);
+    if (!repo) continue;
+    totalAttempted += 1;
+    try {
+      const hnEvents = await fetchHnEvents(repo.owner, repo.repo);
+      const releaseEvents = await fetchReleaseEvents(repo.owner, repo.repo, getJson);
+      const events = appendEventEntries(entity.events, [...hnEvents, ...releaseEvents]);
+      saveProjectEntity({ ...entity, events });
+      totalFetched += 1;
+    } catch (err) {
+      failed += 1;
+      console.error(`Warning: failed to snapshot events for "${entity.id}": ${err.message}`);
+    }
+  }
+
+  console.log(`${totalFetched}/${totalAttempted} project(s) had events snapshotted, ${failed} failed`);
+
+  if (totalAttempted > 0 && totalFetched === 0) {
+    console.error(
+      `Error: 0/${totalAttempted} project(s) were successfully snapshotted — ` +
+        "this looks like a systemic failure (e.g. an invalid/expired token or an API outage), not isolated per-project flakiness."
+    );
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/test/project-events.test.js
+++ b/test/project-events.test.js
@@ -1,0 +1,22 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sortedEvents } from "../scripts/project-events.mjs";
+
+test("sortedEvents sorts an out-of-order events array oldest-first", () => {
+  const events = [
+    { date: "2026-08-07", type: "release", title: "v2.0" },
+    { date: "2026-01-15", type: "hn", title: "Show HN: thing" },
+  ];
+  assert.deepEqual(sortedEvents(events), [
+    { date: "2026-01-15", type: "hn", title: "Show HN: thing" },
+    { date: "2026-08-07", type: "release", title: "v2.0" },
+  ]);
+});
+
+test("sortedEvents returns [] for a project with no events array", () => {
+  assert.deepEqual(sortedEvents(undefined), []);
+});
+
+test("sortedEvents returns [] when given something other than an array", () => {
+  assert.deepEqual(sortedEvents("not an array"), []);
+});

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -1017,6 +1017,28 @@ test("renderProjectPage renders forks/open-issues chips from the latest history 
   assert.doesNotMatch(withoutSnapshot, /Open issues/);
 });
 
+test("renderProjectPage renders an events timeline newest-first, and omits the section entirely when there are no events", () => {
+  const withEvents = renderProjectPage(PROJECT, {
+    domain: PROJECT_DOMAIN,
+    signal: NO_SIGNAL,
+    defaultOgImage: "/og-default.png",
+    eventsSeries: [
+      { date: "2026-07-01", type: "hn", title: "Show HN: llama.cpp", url: "https://hn/1", points: 312 },
+      { date: "2026-08-07", type: "release", title: "v2.0", url: "https://gh/releases/v2.0", points: null },
+    ],
+  });
+  // Newest-first: the release (Aug) appears before the HN post (Jul).
+  const releaseIndex = withEvents.indexOf("v2.0");
+  const hnIndex = withEvents.indexOf("Show HN: llama.cpp");
+  assert.ok(releaseIndex >= 0 && hnIndex >= 0 && releaseIndex < hnIndex);
+  assert.match(withEvents, /href="https:\/\/hn\/1"/);
+  assert.match(withEvents, /312 pts/);
+  assert.match(withEvents, /Aug 7, 2026/);
+
+  const withoutEvents = renderProjectPage(PROJECT, { domain: PROJECT_DOMAIN, signal: NO_SIGNAL, defaultOgImage: "/og-default.png" });
+  assert.doesNotMatch(withoutEvents, /class="project-events"/);
+});
+
 test("renderProjectPage degrades gracefully for a minimal project record with only an id", () => {
   const minimal = { id: "a/b" };
   const html = renderProjectPage(minimal, { domain: PROJECT_DOMAIN, signal: NO_SIGNAL, defaultOgImage: "/og-default.png", basePath: "" });

--- a/test/snapshot-events.test.js
+++ b/test/snapshot-events.test.js
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  hnHitMatchesRepo,
+  mapHnHit,
+  buildHnSearchUrl,
+  fetchHnEvents,
+  isPublishedRelease,
+  mapRelease,
+  fetchReleaseEvents,
+  appendEventEntries,
+} from "../scripts/snapshot-events.mjs";
+
+test("hnHitMatchesRepo accepts a hit whose url contains github.com/<owner>/<repo>", () => {
+  const hit = { url: "https://github.com/facebook/react/releases/tag/v19.0.0" };
+  assert.equal(hnHitMatchesRepo(hit, "facebook", "react"), true);
+});
+
+test("hnHitMatchesRepo is case-insensitive", () => {
+  const hit = { url: "https://GitHub.com/Facebook/React" };
+  assert.equal(hnHitMatchesRepo(hit, "facebook", "react"), true);
+});
+
+test("hnHitMatchesRepo rejects a hit whose url is a different repo entirely (Algolia's tokenized search false positive)", () => {
+  const hit = { url: "https://github.com/someone-else/react-native-thing" };
+  assert.equal(hnHitMatchesRepo(hit, "facebook", "react"), false);
+});
+
+test("hnHitMatchesRepo rejects a hit with no url at all (e.g. a text-only Ask HN post)", () => {
+  assert.equal(hnHitMatchesRepo({ url: null }, "facebook", "react"), false);
+});
+
+test("mapHnHit maps an Algolia hit onto an event entry, linking to the HN discussion itself", () => {
+  const hit = {
+    objectID: "12345",
+    title: "Show HN: React 19",
+    created_at: "2026-08-07T14:32:00.000Z",
+    points: 312,
+  };
+  assert.deepEqual(mapHnHit(hit), {
+    date: "2026-08-07",
+    type: "hn",
+    title: "Show HN: React 19",
+    url: "https://news.ycombinator.com/item?id=12345",
+    points: 312,
+  });
+});
+
+test("buildHnSearchUrl restricts the search to the url field and requests the story tag", () => {
+  const url = buildHnSearchUrl("facebook", "react");
+  assert.match(url, /^https:\/\/hn\.algolia\.com\/api\/v1\/search\?/);
+  assert.match(url, /query=facebook%2Freact/);
+  assert.match(url, /restrictSearchableAttributes=url/);
+  assert.match(url, /tags=story/);
+});
+
+test("fetchHnEvents keeps only matching, above-threshold hits, mapped to event entries", async () => {
+  const hits = [
+    { objectID: "1", url: "https://github.com/facebook/react", title: "Front page", created_at: "2026-08-07T00:00:00.000Z", points: 312 },
+    { objectID: "2", url: "https://github.com/facebook/react", title: "Below threshold", created_at: "2026-08-08T00:00:00.000Z", points: 4 },
+    { objectID: "3", url: "https://github.com/someone-else/react", title: "Unrelated repo", created_at: "2026-08-09T00:00:00.000Z", points: 500 },
+  ];
+  const fetchImpl = async () => ({ ok: true, json: async () => ({ hits }) });
+
+  const result = await fetchHnEvents("facebook", "react", { fetchImpl, pointsThreshold: 50 });
+
+  assert.deepEqual(result, [
+    { date: "2026-08-07", type: "hn", title: "Front page", url: "https://news.ycombinator.com/item?id=1", points: 312 },
+  ]);
+});
+
+test("fetchHnEvents throws with the response status when the request fails", async () => {
+  const fetchImpl = async () => ({ ok: false, status: 429, statusText: "Too Many Requests" });
+  await assert.rejects(
+    () => fetchHnEvents("facebook", "react", { fetchImpl, pointsThreshold: 50 }),
+    (err) => err.status === 429
+  );
+});
+
+test("isPublishedRelease rejects drafts and prereleases, accepts everything else", () => {
+  assert.equal(isPublishedRelease({ draft: false, prerelease: false }), true);
+  assert.equal(isPublishedRelease({ draft: true, prerelease: false }), false);
+  assert.equal(isPublishedRelease({ draft: false, prerelease: true }), false);
+});
+
+test("mapRelease maps a GitHub release onto an event entry, preferring the release name over the tag", () => {
+  const release = {
+    name: "v19.0.0 — Actions",
+    tag_name: "v19.0.0",
+    html_url: "https://github.com/facebook/react/releases/tag/v19.0.0",
+    published_at: "2026-08-07T14:32:00.000Z",
+  };
+  assert.deepEqual(mapRelease(release), {
+    date: "2026-08-07",
+    type: "release",
+    title: "v19.0.0 — Actions",
+    url: "https://github.com/facebook/react/releases/tag/v19.0.0",
+    points: null,
+  });
+});
+
+test("mapRelease falls back to the tag name when the release has no name", () => {
+  const release = { name: "", tag_name: "v19.0.0", html_url: "https://x/y", published_at: "2026-08-07T00:00:00.000Z" };
+  assert.equal(mapRelease(release).title, "v19.0.0");
+});
+
+test("fetchReleaseEvents drops drafts/prereleases and maps the rest", async () => {
+  const releases = [
+    { name: "v2.0", tag_name: "v2.0", html_url: "https://x/2", published_at: "2026-08-01T00:00:00.000Z", draft: false, prerelease: false },
+    { name: "v2.1-rc1", tag_name: "v2.1-rc1", html_url: "https://x/rc1", published_at: "2026-08-05T00:00:00.000Z", draft: false, prerelease: true },
+  ];
+  const getJson = async () => releases;
+
+  const result = await fetchReleaseEvents("facebook", "react", getJson);
+
+  assert.deepEqual(result, [{ date: "2026-08-01", type: "release", title: "v2.0", url: "https://x/2", points: null }]);
+});
+
+test("appendEventEntries merges new events into existing ones, sorted by date", () => {
+  const existing = [{ date: "2026-08-01", type: "release", title: "v2.0", url: "https://x/2", points: null }];
+  const incoming = [{ date: "2026-07-01", type: "hn", title: "Launch", url: "https://hn/1", points: 200 }];
+  assert.deepEqual(appendEventEntries(existing, incoming), [
+    { date: "2026-07-01", type: "hn", title: "Launch", url: "https://hn/1", points: 200 },
+    { date: "2026-08-01", type: "release", title: "v2.0", url: "https://x/2", points: null },
+  ]);
+});
+
+test("appendEventEntries dedupes by url, letting the new value win (e.g. an HN post's points climbing)", () => {
+  const existing = [{ date: "2026-08-01", type: "hn", title: "Launch", url: "https://hn/1", points: 120 }];
+  const incoming = [{ date: "2026-08-01", type: "hn", title: "Launch", url: "https://hn/1", points: 340 }];
+  assert.deepEqual(appendEventEntries(existing, incoming), [
+    { date: "2026-08-01", type: "hn", title: "Launch", url: "https://hn/1", points: 340 },
+  ]);
+});
+
+test("appendEventEntries treats a missing existing array as empty", () => {
+  const incoming = [{ date: "2026-08-01", type: "release", title: "v2.0", url: "https://x/2", points: null }];
+  assert.deepEqual(appendEventEntries(undefined, incoming), incoming);
+});

--- a/test/star-history.test.js
+++ b/test/star-history.test.js
@@ -7,6 +7,7 @@ import {
   sortedHistory,
   buildSparklinePath,
   starHistoryCaption,
+  formatEventDate,
 } from "../app/shared/star-history.js";
 
 test("githubRepoUrl builds a direct link from an owner/repo id", () => {
@@ -103,4 +104,8 @@ test("starHistoryCaption summarizes the first-to-last change with a short start 
     { date: "2026-08-13", stars: 1240 },
   ];
   assert.equal(starHistoryCaption(series), "1,180 → 1,240 stars since Aug 8");
+});
+
+test("formatEventDate includes the year, unlike formatShortDate's month/day-only", () => {
+  assert.equal(formatEventDate("2025-08-08"), "Aug 8, 2025");
 });


### PR DESCRIPTION
## Summary
Correlates star growth with real-world events, shown chronologically on each project's canonical page.

- New daily job `scripts/snapshot-events.mjs` (added as a step in `.github/workflows/snapshot-history.yml`, same commit as the star snapshot) fetches:
  - HN stories whose url matches the repo (Algolia HN Search API, restricted to the `url` field, with a strict post-filter against Algolia's tokenized-search false positives), kept only at ≥50 points.
  - Non-draft, non-prerelease GitHub releases, via the same `gh`-token API the star snapshot already calls.
- Both merge into a new `events` array per project entity (dedup by url, sorted ascending) — unlike `history`, never pruned.
- `renderProjectPage` renders it as a newest-first "Timeline" list, capped to the most recent 20 entries, below the repo stats.
- No LLM-based "is this interesting" classification for v1 — deferred, noted in `product.md`'s Data foundation section for later.
- `MVP.md` item moved to `product.md`'s Shipped section.

## Test plan
- `npm test` — 6,110/6,110 passing.
- `npm run generate` — full site build succeeds.
- Manually verified the rendered timeline (order, badges, points, dates) in the browser preview against a temporary sample-events fixture, then reverted the fixture before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)