### PR TITLE
fix: fall back to the default API URL on an empty (not just unset) env var

### DIFF
--- a/scripts/data-store.mjs
+++ b/scripts/data-store.mjs
@@ -19,7 +19,16 @@
 export const SCHEMA_VERSION = 1;
 
 function baseUrl() {
-  return (process.env.AWESOMEMAP_DATA_API_URL ?? "https://awesomemap-data.haggai-shachar.workers.dev").replace(/\/$/, "");
+  // `||`, not `??`: GitHub Actions injects an env var declared in a
+  // workflow's `env:` block as an empty string (not an absent variable)
+  // whenever the secret it references doesn't exist — e.g.
+  // `AWESOMEMAP_DATA_API_URL: ${{ secrets.AWESOMEMAP_DATA_API_URL }}` in
+  // deploy.yml becomes `AWESOMEMAP_DATA_API_URL=""` if that secret was
+  // ever unset. `??` only falls back on null/undefined, so it would build
+  // a broken relative URL ("/domains") instead of the production default
+  // — this happened in production (deploy.yml run 33898487635, "Failed to
+  // parse URL from /domains") after the secret was removed from the repo.
+  return (process.env.AWESOMEMAP_DATA_API_URL || "https://awesomemap-data.haggai-shachar.workers.dev").replace(/\/$/, "");
 }
 
 async function apiFetch(path, { fetchImpl = fetch } = {}) {

--- a/test/data-store.test.js
+++ b/test/data-store.test.js
@@ -76,3 +76,20 @@ test("loadAllDomains defaults to the live production API when AWESOMEMAP_DATA_AP
     process.env.AWESOMEMAP_DATA_API_URL = original;
   }
 });
+
+test("loadAllDomains also defaults to the live production API when AWESOMEMAP_DATA_API_URL is set but empty", async () => {
+  // Regression test: GitHub Actions injects a workflow env var as an empty
+  // string (not an absent variable) when the secret it references from
+  // `${{ secrets.FOO }}` doesn't exist — this broke deploy.yml in
+  // production (run 33898487635) when AWESOMEMAP_DATA_API_URL's secret
+  // was removed from the repo; `??` didn't catch the empty string.
+  const original = process.env.AWESOMEMAP_DATA_API_URL;
+  process.env.AWESOMEMAP_DATA_API_URL = "";
+  try {
+    const { fetchImpl, calls } = fakeFetch([{ status: 200, body: [] }]);
+    await loadAllDomains({ fetchImpl });
+    assert.equal(calls[0].url, "https://awesomemap-data.haggai-shachar.workers.dev/domains");
+  } finally {
+    process.env.AWESOMEMAP_DATA_API_URL = original;
+  }
+});


### PR DESCRIPTION
## Summary

`deploy.yml`'s recent GitHub Pages run failed: https://github.com/haggaishachar/awesomemap/actions/runs/33898487635/job/101106713028

```
TypeError: Failed to parse URL from /domains
  ...
  input: '/domains'
```

Root cause: `deploy.yml` passes `AWESOMEMAP_DATA_API_URL: ${{ secrets.AWESOMEMAP_DATA_API_URL }}`. That secret no longer exists in this repo (`gh secret list` now shows only `OPENROUTER_API_KEY`) — GitHub Actions injects the env var as an **empty string** in that case, not an absent variable. `scripts/data-store.mjs`'s `baseUrl()` used `??`, which only falls back on `null`/`undefined`, so it built a relative URL (`/domains`) instead of the hardcoded production default, and Node's `fetch` rejected it.

## Fix

Switch `??` to `||` in `baseUrl()`, so an empty string falls back to the default the same way an unset variable already did. Added a regression test reproducing the exact failure mode (`AWESOMEMAP_DATA_API_URL=""`).

## Testing

- 368/368 tests passing (RED confirmed against the old `??` logic before applying the fix, GREEN after).
- `AWESOMEMAP_DATA_API_URL="" npm run generate` — the exact env shape CI produced — now succeeds (previously reproduced the production failure).

## Note

The missing `AWESOMEMAP_DATA_API_URL`/`AWESOMEMAP_DATA_INTERNAL_TOKEN` secrets aren't restored by this PR (I don't have the values) — this fix means deploys work fine without them either way, since the default *is* the production URL. Worth checking why they disappeared if you want `deploy.yml`'s explicit secret-based override to actually do anything in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)