### PR TITLE
feat: rolled-up "why" summary above the project page Timeline

### DIFF
--- a/app/shared/treemap.css
+++ b/app/shared/treemap.css
@@ -1470,6 +1470,12 @@ a.momentum-row-name:hover {
   margin: 0 0 8px;
 }
 
+.project-events-summary {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  margin: 0 0 12px;
+}
+
 .project-events-list {
   list-style: none;
   margin: 0;

--- a/scripts/render-page.mjs
+++ b/scripts/render-page.mjs
@@ -1306,6 +1306,50 @@ function renderProjectTagChips(tags, basePath) {
 const EVENTS_TIMELINE_LIMIT = 20;
 const EVENT_TYPE_LABELS = { hn: "HN", lobsters: "Lobsters", reddit: "Reddit", producthunt: "Product Hunt", bluesky: "Bluesky", blog: "Blog" };
 
+// Emoji + noun phrase per event type for the rolled-up summary line above
+// the timeline — one group per type actually present, e.g. "💬 3 Hacker
+// News discussions". Keyed in the display order the summary renders
+// mapped types in; an unmapped type (see EVENT_TYPE_LABELS' own fallback)
+// falls back to a generic 🔗 "mention" phrase built from its raw type
+// string, appended after every mapped type.
+const EVENT_SUMMARY_PHRASES = {
+  hn: { emoji: "💬", singular: "Hacker News discussion", plural: "Hacker News discussions" },
+  lobsters: { emoji: "🦞", singular: "Lobsters discussion", plural: "Lobsters discussions" },
+  reddit: { emoji: "👽", singular: "Reddit discussion", plural: "Reddit discussions" },
+  producthunt: { emoji: "📣", singular: "Product Hunt launch", plural: "Product Hunt launches" },
+  bluesky: { emoji: "🦋", singular: "Bluesky mention", plural: "Bluesky mentions" },
+  blog: { emoji: "📰", singular: "publication", plural: "publications" },
+};
+
+/**
+ * Rolls `eventsSeries` up into one summary line — "how much coverage did
+ * this project get, and where" — grouped by `event.type` and rendered in
+ * `EVENT_SUMMARY_PHRASES`' fixed key order (so the line reads the same
+ * regardless of chronological mix), with any unmapped type appended after
+ * in first-seen order. Counts the *full* series, not
+ * `renderProjectEventsTimeline`'s `EVENTS_TIMELINE_LIMIT`-capped rendered
+ * slice, since this answers "total coverage," not "what's listed below."
+ * Returns "" for an empty series, same convention as the timeline itself.
+ */
+function renderProjectEventsSummary(eventsSeries) {
+  if (!Array.isArray(eventsSeries) || eventsSeries.length === 0) return "";
+  const counts = new Map();
+  for (const event of eventsSeries) {
+    counts.set(event.type, (counts.get(event.type) ?? 0) + 1);
+  }
+  const mappedTypes = Object.keys(EVENT_SUMMARY_PHRASES).filter((type) => counts.has(type));
+  const unmappedTypes = [...counts.keys()].filter((type) => !Object.hasOwn(EVENT_SUMMARY_PHRASES, type));
+  const groups = [...mappedTypes, ...unmappedTypes].map((type) => {
+    const count = counts.get(type);
+    const phrase = Object.hasOwn(EVENT_SUMMARY_PHRASES, type)
+      ? EVENT_SUMMARY_PHRASES[type]
+      : { emoji: "🔗", singular: `${type} mention`, plural: `${type} mentions` };
+    const label = count === 1 ? phrase.singular : phrase.plural;
+    return `${phrase.emoji} ${formatCount(count)} ${escapeHtml(label)}`;
+  });
+  return `<p class="project-events-summary">${groups.join(" · ")}</p>`;
+}
+
 /**
  * Server-rendered chronological timeline of external events (HN, Lobsters,
  * Reddit, Product Hunt, Bluesky, blog/launch posts) for a project page — the "why did
@@ -1322,6 +1366,9 @@ const EVENT_TYPE_LABELS = { hn: "HN", lobsters: "Lobsters", reddit: "Reddit", pr
  * a hardcoded string precisely because a new source can add a sixth without
  * structural changes; the fallback (`EVENT_TYPE_LABELS[event.type] ?? event.type`)
  * means an unmapped type still renders acceptably until the map is updated.
+ * Above the list, `renderProjectEventsSummary` rolls the same `eventsSeries`
+ * up into a one-line "how much coverage, and where" count per type — a
+ * reader can get the gist without scanning the whole list.
  */
 function renderProjectEventsTimeline(eventsSeries) {
   if (!Array.isArray(eventsSeries) || eventsSeries.length === 0) return "";
@@ -1346,6 +1393,7 @@ function renderProjectEventsTimeline(eventsSeries) {
   return `
     <div class="project-events">
       <h2 class="project-events-heading">Timeline</h2>
+      ${renderProjectEventsSummary(eventsSeries)}
       <ul class="project-events-list">${rows}</ul>
     </div>`;
 }

--- a/test/render-page.test.js
+++ b/test/render-page.test.js
@@ -1311,9 +1311,54 @@ test("renderProjectPage renders an events timeline newest-first, and omits the s
   assert.match(withEvents, /href="https:\/\/hn\/1"/);
   assert.match(withEvents, /312 pts/);
   assert.match(withEvents, /Aug 7, 2026/);
+  // Rolled-up summary above the list, singular/plural-aware.
+  assert.match(withEvents, /class="project-events-summary">💬 2 Hacker News discussions</);
 
   const withoutEvents = renderProjectPage(PROJECT, { domain: PROJECT_DOMAIN, signal: NO_SIGNAL, defaultOgImage: "/og-default.png" });
   assert.doesNotMatch(withoutEvents, /class="project-events"/);
+  assert.doesNotMatch(withoutEvents, /class="project-events-summary"/);
+});
+
+test("renderProjectPage's events summary groups by type in a fixed order, singularizes a count of one, and falls back for an unmapped type", () => {
+  const html = renderProjectPage(PROJECT, {
+    domain: PROJECT_DOMAIN,
+    signal: NO_SIGNAL,
+    defaultOgImage: "/og-default.png",
+    eventsSeries: [
+      // Deliberately out of the summary's fixed display order, and with a
+      // blog event chronologically first, to prove grouping doesn't just
+      // mirror encounter order.
+      { date: "2026-08-01", type: "blog", title: "Blog post one", url: "https://someblog.dev/1" },
+      { date: "2026-08-02", type: "blog", title: "Blog post two", url: "https://someblog.dev/2" },
+      { date: "2026-08-03", type: "hn", title: "Show HN", url: "https://hn/1" },
+      { date: "2026-08-04", type: "hn", title: "HN again", url: "https://hn/2" },
+      { date: "2026-08-05", type: "hn", title: "HN thrice", url: "https://hn/3" },
+      { date: "2026-08-06", type: "producthunt", title: "PH launch", url: "https://producthunt.com/posts/1" },
+      { date: "2026-08-07", type: "future-source", title: "Unmapped", url: "https://example.com/1" },
+    ],
+  });
+  const summaryMatch = html.match(/<p class="project-events-summary">([^<]*)<\/p>/);
+  assert.ok(summaryMatch, "expected a project-events-summary line");
+  assert.strictEqual(
+    summaryMatch[1],
+    "💬 3 Hacker News discussions · 📣 1 Product Hunt launch · 📰 2 publications · 🔗 1 future-source mention"
+  );
+});
+
+test("renderProjectPage's events summary counts the full events series, not just the capped rendered list", () => {
+  const events = Array.from({ length: 25 }, (_, i) => ({
+    date: `2026-01-${String(i + 1).padStart(2, "0")}`,
+    type: "hn",
+    title: `HN post ${i + 1}`,
+    url: `https://hn/${i + 1}`,
+  }));
+  const html = renderProjectPage(PROJECT, {
+    domain: PROJECT_DOMAIN,
+    signal: NO_SIGNAL,
+    defaultOgImage: "/og-default.png",
+    eventsSeries: events,
+  });
+  assert.match(html, /class="project-events-summary">💬 25 Hacker News discussions</);
 });
 
 test("renderProjectPage renders known non-HN event types with their real label, and an unknown type with its raw type string", () => {


### PR DESCRIPTION
## What kind of change is this?

- [x] Something else (code, docs, CI)

## Checklist

- [x] `npm run generate` builds locally with no errors
- [x] `npm test` passes locally (409/409)

## Description

MVP item 3: `renderProjectEventsTimeline` rendered every external event
(HN, Lobsters, Reddit, Product Hunt, Bluesky, blog) as a flat
chronological list with no rolled-up count, so a reader had to scan the
whole list to answer "how much coverage did this get, and where."

Adds `renderProjectEventsSummary`, which groups the same `eventsSeries`
by `event.type` — no new data, purely a render-layer addition — into a
one-line, emoji-tagged, singular/plural-aware count per type rendered
above the "Timeline" list, e.g.:

> 📰 2 publications · 💬 3 Hacker News discussions · 📣 1 Product Hunt launch

Counts the full events series rather than the list's own
20-entry-capped render slice, since this answers "total coverage," not
"what's listed below." Omitted entirely alongside the rest of the
Timeline block for a project with no events yet.

Also moves this item from `MVP.md` to `product.md`'s Shipped section
per their own bookkeeping convention (tracked in a separate,
non-code repo — not part of this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)